### PR TITLE
release(mcp-v0.7.4): bump fsb-mcp-server

### DIFF
--- a/mcp-server/build/index.js
+++ b/mcp-server/build/index.js
@@ -87,9 +87,9 @@ export function formatHeartbeat(lastHeartbeatAt, nowMs = Date.now()) {
     if (lastHeartbeatAt === null)
         return 'none';
     const ageMs = Math.max(0, nowMs - lastHeartbeatAt);
-    if (ageMs > 10000)
+    if (ageMs > 10_000)
         return 'stale';
-    return `${(ageMs / 1000).toFixed(ageMs >= 5000 ? 0 : 1)}s`;
+    return `${(ageMs / 1000).toFixed(ageMs >= 5_000 ? 0 : 1)}s`;
 }
 export function buildCompactStatusFields(diagnostics, nowMs = Date.now()) {
     return [
@@ -282,7 +282,7 @@ async function runDoctor(flags) {
 }
 async function runWaitForExtension(flags) {
     const bridge = new WebSocketBridge();
-    const timeoutMs = readNumberFlag(flags, 'timeout', 15000);
+    const timeoutMs = readNumberFlag(flags, 'timeout', 15_000);
     try {
         await bridge.connect();
     }

--- a/mcp-server/build/version.d.ts
+++ b/mcp-server/build/version.d.ts
@@ -1,7 +1,7 @@
 export declare const FSB_SERVER_NAME = "fsb";
-export declare const FSB_MCP_VERSION = "0.7.3";
+export declare const FSB_MCP_VERSION = "0.7.4";
 export declare const FSB_EXTENSION_BRIDGE_PORT = 7225;
-export declare const FSB_EXTENSION_BRIDGE_URL: string;
+export declare const FSB_EXTENSION_BRIDGE_URL = "ws://localhost:7225";
 export declare const DEFAULT_HTTP_HOST = "127.0.0.1";
 export declare const DEFAULT_HTTP_PORT = 7226;
 export declare const FSB_REGISTRY_NAME = "io.github.lakshmanturlapati/fsb-mcp-server";

--- a/mcp-server/build/version.js
+++ b/mcp-server/build/version.js
@@ -1,5 +1,5 @@
 export const FSB_SERVER_NAME = 'fsb';
-export const FSB_MCP_VERSION = '0.7.3';
+export const FSB_MCP_VERSION = '0.7.4';
 export const FSB_EXTENSION_BRIDGE_PORT = 7225;
 export const FSB_EXTENSION_BRIDGE_URL = `ws://localhost:${FSB_EXTENSION_BRIDGE_PORT}`;
 export const DEFAULT_HTTP_HOST = '127.0.0.1';

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsb-mcp-server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsb-mcp-server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsb-mcp-server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "FSB Browser Automation MCP Server",
   "license": "BUSL-1.1",
   "author": "Lakshman Turlapati",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.lakshmanturlapati/fsb-mcp-server",
   "title": "FSB MCP Server",
   "description": "Control the FSB browser extension from any MCP client using a local stdio or Streamable HTTP companion runtime.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "fsb-mcp-server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "transport": {
         "type": "stdio"
       }

--- a/mcp-server/src/version.ts
+++ b/mcp-server/src/version.ts
@@ -1,5 +1,5 @@
 export const FSB_SERVER_NAME = 'fsb';
-export const FSB_MCP_VERSION = '0.7.3';
+export const FSB_MCP_VERSION = '0.7.4';
 export const FSB_EXTENSION_BRIDGE_PORT = 7225;
 export const FSB_EXTENSION_BRIDGE_URL = `ws://localhost:${FSB_EXTENSION_BRIDGE_PORT}`;
 export const DEFAULT_HTTP_HOST = '127.0.0.1';

--- a/tests/mcp-version-parity.test.js
+++ b/tests/mcp-version-parity.test.js
@@ -22,7 +22,7 @@ function assertEqual(actual, expected, msg) {
 }
 
 const repoRoot = path.resolve(__dirname, '..');
-const canonicalVersion = '0.7.3';
+const canonicalVersion = '0.7.4';
 
 function readText(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');


### PR DESCRIPTION
## Summary

Cuts mcp-v0.7.4 for changes since mcp-v0.7.3:
- bcd4735 reorder tool list / refresh annotations (visual-session first, execute_js power-tool)
- 2f755bc 21-platform MCP installer + Phase 214 regression closure
- 9f31ed0 background-agents sunset (block-comment agents/*, gate registerAgentTools)
- 5f7da1a guardrails preferring manual tools over run_task autopilot

## Test plan

- [ ] CI all-green on this PR
- [ ] After merge, push tag \`mcp-v0.7.4\` → npm-publish.yml publishes to npm + creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)