### PR TITLE
ci(npm-publish): trigger only on mcp-v* tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,10 @@ name: npm-publish
 on:
   push:
     tags:
-      - 'v*'
+      # Only mcp-server release tags trigger npm publish. Repo-wide milestone
+      # tags (v0.9.x) are markers, not publishable artifacts; including them
+      # caused every milestone tag to fail npm-publish (re-publishing an
+      # existing mcp-server version).
       - 'mcp-v*'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Restricts \`npm-publish.yml\` to \`mcp-v*\` tags only.

## Why

Milestone tags (v0.9.x) are repo-wide markers, not publishable artifacts. Including them in the trigger list caused every milestone tag push to fail npm-publish — the workflow tries to re-publish whatever version is in \`mcp-server/package.json\`, which is already on npm.

Verified by checking prior runs: \`v0.9.45-rc3\` (last \`v*\` tag pushed) → npm-publish completed failure.

## Test plan

- [ ] CI all-green on this PR
- [ ] After merge, the upcoming v0.9.46 milestone tag (from \`/gsd-complete-milestone\`) will not trigger npm-publish
- [ ] Future \`mcp-v*\` tags continue to publish normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)