### PR TITLE
docs: open milestone v0.9.47 Workspace Reorganization

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -16,16 +16,37 @@ FSB is an AI-powered browser automation Chrome extension that executes tasks thr
 
 **CI:** PRs to `main` gated by `ci / all-green` status check (extension + mcp-smoke + showcase build).
 
-## Next Milestone Goals
+## Current Milestone: v0.9.47 Workspace Reorganization (extension / mcp / showcase)
 
-To be defined. Use `/gsd-new-milestone` to scope, research, and define requirements. Carry-forward backlog candidates:
+**Goal:** Reorganize the repo into three clearly-bounded top-level packages — `extension/`, `mcp/`, `showcase/` — each owning its own assets, README, and tests, so cross-package boundaries are explicit and future work has a single place to land.
 
-- **Angular 19 → 20 migration** (deadline 2026-05-19; Angular 19 EOL — must land before this date)
+**Target features:**
+- Move all extension files (`background.js`, `manifest.json`, `content/`, `ui/`, `agents/`, `ws/`, `ai/`, `offscreen/`, `lib/`, `assets/`, `canvas-interceptor.js`) under `extension/`; update manifest paths and any cross-package imports
+- Rename `mcp-server/` → `mcp/`; update `npm-publish.yml` `working-directory` and `version-parity` test paths; npm package name `fsb-mcp-server` is unchanged (folder rename only)
+- Move deploy backend `server/` → `showcase/server/`; update `fly.toml`, `Dockerfile`, `.github/workflows/deploy.yml` paths
+- Each package gets its own `README.md`; root `README.md` becomes a repo overview pointing at the three packages
+- Update `ci.yml` job paths so the existing `all-green` gate still passes
+- Update `scripts/validate-extension.mjs` to walk `extension/`
+- Test-suite paths updated; CI behavior unchanged (`extension`, `mcp-smoke`, `showcase` jobs + `all-green`)
+
+**Why now:** The repo currently has extension code, MCP server, showcase, and deploy backend interleaved at the root. Cross-package boundaries are implicit and ad-hoc. A clean three-package layout makes future work — Angular 20 migration, MCP feature work, extension features — easier to scope and review. The reorg is mechanical and well-defined; doing it now (before A20) means the migration phase work lands inside a clean `showcase/` package.
+
+**Out of scope (deferred):**
+- Angular 19 → 20 migration (next milestone, v0.9.48 — Angular 19 EOL is 2026-05-19, must land before)
+- New build system / bundler / monorepo tooling (workspaces, Nx, Turborepo) — folder layout only
+- Code refactors beyond import-path fixes
+- Renaming the npm package `fsb-mcp-server`
+
+## Previous Next-Milestone Candidates (rolled forward)
+
+These remain on the radar after v0.9.47 ships:
+
+- Angular 19 → 20 migration (deadline 2026-05-19) — first candidate for v0.9.48
 - FAQ page + `FAQPage` JSON-LD (DISCO-FUTURE-01)
-- Comparison pages (`/vs-browser-use`, `/vs-project-mariner`, `/vs-stagehand`, `/vs-browseros`) (DISCO-FUTURE-02)
-- Per-route OG images (CRAWL-FUTURE-01; design pass)
-- Off-page push (Show HN, Reddit launches, awesome-list PRs, demo video) (DISCO-FUTURE-04)
-- Search Console + Bing Webmaster Tools registration + monitoring (DISCO-FUTURE-05)
+- Comparison pages (DISCO-FUTURE-02)
+- Per-route OG images (CRAWL-FUTURE-01)
+- Off-page push (DISCO-FUTURE-04)
+- Search Console + Bing Webmaster Tools registration (DISCO-FUTURE-05)
 
 <details>
 <summary>Previous milestones (collapsed)</summary>

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,100 @@
+# Requirements: FSB v0.9.47 Workspace Reorganization (extension / mcp / showcase)
+
+**Defined:** 2026-05-02
+**Core Value:** Reliable single-attempt execution — the AI decides correctly, the mechanics execute precisely
+
+## Milestone Goal
+
+Reorganize the repo into three clearly-bounded top-level packages — `extension/`, `mcp/`, `showcase/` — each owning its own assets, README, and tests. Cross-package boundaries become explicit; future work (Angular 20 migration, MCP features, extension features) has a single obvious place to land.
+
+## Already Validated (counted toward this milestone)
+
+None. v0.9.47 is purely structural — no prior phase landed any of these requirements.
+
+## v1 Requirements (in scope for v0.9.47)
+
+### Extension Move (EXT)
+
+- [ ] **EXT-01**: All extension source files move under `extension/`: `background.js`, `manifest.json`, `canvas-interceptor.js`, `content/`, `ui/`, `agents/`, `ws/`, `ai/`, `offscreen/`, `lib/`, `assets/`, `config/` (extension config; do not move `.github/`/`.planning/` etc.). After the move, no extension-loadable JS file exists at repo root.
+- [ ] **EXT-02**: `extension/manifest.json` references all paths relative to itself (e.g., `background.service_worker = "background.js"`, not `"extension/background.js"`); the extension loads cleanly when the user points Chrome at `extension/` as the unpacked extension root.
+- [ ] **EXT-03**: All `importScripts(...)` calls inside `extension/background.js` resolve relative to `extension/` (e.g., `importScripts('ai/agent-loop.js')` works because background.js is now at `extension/background.js` and `ai/` is at `extension/ai/`); zero runtime path errors when service worker boots.
+- [ ] **EXT-04**: All HTML files in `extension/ui/` reference scripts/CSS via paths relative to `extension/ui/` (existing relative paths like `../background.js` adjust to `../background.js` from the new root). Manual smoke: open `extension/ui/control_panel.html` from `chrome-extension://...` URL — page loads, no 404s in DevTools console.
+- [ ] **EXT-05**: `extension/README.md` exists and describes: how to load the extension as unpacked, where to find Chrome Web Store packaging script, key entry points (`background.js`, `manifest.json`, `content/`, `ui/`).
+
+### MCP Rename (MCP)
+
+- [ ] **MCP-01**: `mcp-server/` is renamed to `mcp/`. The directory contents are unchanged (no internal restructure); the npm package name `fsb-mcp-server` in `mcp/package.json` is unchanged; all internal paths inside `mcp/src/` continue to resolve.
+- [ ] **MCP-02**: `mcp/build` script (`tsc && cp ../ai/tool-definitions.js ai/tool-definitions.cjs`) is updated to point at the new extension location: `cp ../extension/ai/tool-definitions.js ai/tool-definitions.cjs` (since `ai/` moved into `extension/` per EXT-01). The `mcp/build/` artifacts continue to be produced identically.
+- [ ] **MCP-03**: `.github/workflows/npm-publish.yml` `defaults.run.working-directory` is updated from `mcp-server` to `mcp`; the workflow continues to publish `fsb-mcp-server@<version>` to npm on `mcp-v*` tag pushes (no functional change to the publish step itself).
+- [ ] **MCP-04**: `tests/mcp-version-parity.test.js` and any other test that hardcodes `mcp-server/` is updated to read from `mcp/`. All existing MCP smoke tests (`mcp-lifecycle-smoke`, `mcp-tool-smoke`, etc.) pass.
+- [ ] **MCP-05**: `mcp/README.md` exists (carrying over from `mcp-server/README.md` if present, or new). It describes installation (`npx fsb-mcp-server`), CLI verbs, MCP client integration.
+
+### Showcase Server Move (SRV)
+
+- [ ] **SRV-01**: `server/` (Express + SQLite deploy backend) is moved to `showcase/server/`. Internal file structure unchanged.
+- [ ] **SRV-02**: `Dockerfile` `COPY` and `CMD` paths are updated to reference `showcase/server/server.js` (or whichever entrypoint), and the Dockerfile builds successfully (`docker build .` exits 0). If the Dockerfile copies `package.json` from `server/`, that path becomes `showcase/server/package.json`.
+- [ ] **SRV-03**: `fly.toml` `[build]` and `[processes]` directives continue to point at the right artifact post-move; `flyctl deploy --remote-only` (the actual deploy.yml command) succeeds in CI.
+- [ ] **SRV-04**: `.github/workflows/deploy.yml` paths-ignore list is updated as needed; the workflow still triggers on push-to-main and runs the same `flyctl deploy` step.
+- [ ] **SRV-05**: Production deploy works end-to-end after merge — `https://full-selfbrowsing.com/` returns 200 with prerendered HTML; `/dashboard` SPA shell still bootstraps.
+
+### Documentation (DOC)
+
+- [ ] **DOC-01**: Root `README.md` is rewritten as a repo overview: short project description, three-package map (extension/ + mcp/ + showcase/) with one-paragraph description and link to each sub-README, build/dev quickstart, license, contribution pointer.
+- [ ] **DOC-02**: `extension/README.md` covers extension-specific docs (per EXT-05).
+- [ ] **DOC-03**: `mcp/README.md` covers MCP-server-specific docs (per MCP-05).
+- [ ] **DOC-04**: `showcase/README.md` covers showcase-specific docs: how to dev the Angular site (`npm start` in `showcase/angular`), how the deploy backend works (`showcase/server/`), how prerender + crawler files are generated, link to `showcase/angular/README.md` if any.
+
+### CI / Tooling (CI)
+
+- [ ] **CI-01**: `.github/workflows/ci.yml` job paths are updated: `extension` job points at `extension/` for `validate:extension` + tests; `mcp-smoke` job uses `mcp/` working-directory; `showcase` job uses `showcase/angular/` (unchanged but verified).
+- [ ] **CI-02**: `scripts/validate-extension.mjs` walks `extension/` (not the repo root) for the manifest sanity + JS syntax check. Exit-zero on a clean extension/.
+- [ ] **CI-03**: Root `package.json` test script is updated: every `node tests/*.test.js` line resolves to the new test location (`extension/tests/*.test.js` or wherever tests land per EXT-01); the existing `npm test` invocation succeeds in CI.
+- [ ] **CI-04**: `npm run validate:extension`, `npm run test:mcp-smoke`, `npm run showcase:build` all continue to work from repo root (script invocations may move into per-package package.jsons but root-level orchestration scripts remain).
+
+### Validation (VAL)
+
+- [ ] **VAL-01**: `npm publish` from `mcp/` produces an identical-to-before tarball (same files, same package name, same version) — verified via `npm pack --dry-run` diff against the published `fsb-mcp-server@0.7.4` tarball (allow only path changes inside the tarball if any, no surprise file additions/deletions).
+- [ ] **VAL-02**: Loading `extension/` as an unpacked Chrome extension works end-to-end: extension installs, popup opens, side panel opens, control panel opens, a basic automation task runs (smoke-level — open `chrome://newtab`, type a search, observe glow). Manual UAT.
+- [ ] **VAL-03**: Production deploy after merge serves `https://full-selfbrowsing.com/` correctly, prerender + crawler files intact (re-verified via `smoke-crawler.mjs` against production).
+- [ ] **VAL-04**: After PR merge, fresh clone of `main` followed by `npm install && npm test && npm run validate:extension && npm run test:mcp-smoke && npm run showcase:build` exits 0 — proves the reorg holds for a fresh-checkout developer.
+
+## Future Requirements (deferred to v0.9.48+)
+
+- **A20-01..N**: Angular 19 → 20 migration (deadline 2026-05-19) — first candidate for v0.9.48
+- **CRAWL-FUTURE-01**: Per-route OG images
+- **DISCO-FUTURE-01..05**: FAQ page, comparison pages, off-page push, GSC + Bing Webmaster registration
+
+## Out of Scope (explicit exclusions)
+
+- **Workspace tooling** (npm workspaces, Yarn workspaces, Nx, Turborepo) — folder rename only; tooling change is a separate milestone if ever
+- **Renaming the npm package `fsb-mcp-server`** — already on npm at 0.7.4; folder rename does NOT change package name
+- **Code refactors beyond import-path fixes** — no functional changes; this milestone is mechanical
+- **Bundling / transpiling extension code** — extension stays raw JS loaded by Chrome
+- **New CI matrix** (per-package independent CI runners) — keep the existing `extension` + `mcp-smoke` + `showcase` + `all-green` job structure with paths updated
+- **MCP-server semver bump** — folder rename doesn't justify a release; next mcp-v* tag is whenever the next functional change lands
+
+## Known Tech Debt
+
+- **Angular 19 EOL: 2026-05-19** — must migrate to A20 next milestone (v0.9.48)
+- **Cross-package import path: `mcp/build` script `cp ../extension/ai/tool-definitions.js`** — couples mcp-server build to extension layout. Tolerable for now; revisit if mcp/ should own its own copy of tool-definitions instead of cross-package symlink-style copy.
+- **Dockerfile + fly.toml hardcoded paths** — manual update required; risk of drift if anyone restructures showcase/server/ later. Mitigation: deploy.yml verify smoke against production catches this.
+
+## Traceability
+
+Every v1 requirement maps to exactly one phase. The traceability table below is filled by the roadmapper.
+
+| REQ-ID | Phase | Plan | Status |
+|--------|-------|------|--------|
+| EXT-01..05 | 217 | TBD | active |
+| MCP-01..05 | 218 | TBD | active |
+| SRV-01..05 | 219 | TBD | active |
+| DOC-01..04 | 220 | TBD | active |
+| CI-01..04 | 220 | TBD | active |
+| VAL-01..04 | 220 | TBD | active |
+
+**Coverage:** 27/27 requirements mapped. No orphans, no duplicates.
+
+**Phase distribution (preliminary):** Phase 217 = 5 (EXT-01..05). Phase 218 = 5 (MCP-01..05). Phase 219 = 5 (SRV-01..05). Phase 220 = 12 (DOC + CI + VAL).
+
+---
+*Defined: 2026-05-02*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,10 +2,13 @@
 
 ## Status
 
-Between milestones. v0.9.46 (Site Discoverability — SEO + GEO) shipped 2026-05-02. Next milestone TBD; start with `/gsd-new-milestone` to define scope and requirements.
+Active milestone: **v0.9.47 Workspace Reorganization (extension / mcp / showcase)**.
+
+Reorganize the repo into three clearly-bounded top-level packages — `extension/`, `mcp/`, `showcase/` — each owning its own assets, README, and tests. Cross-package boundaries become explicit; future work has a single obvious place to land. Mechanical, well-defined work; no functional changes.
 
 ## Milestones
 
+- 🟡 **v0.9.47 Workspace Reorganization** -- in progress (started 2026-05-02)
 - ✅ **v0.9.46 Site Discoverability (SEO + GEO)** -- shipped 2026-05-02
 - ✅ **v0.9.45rc1 Sync Surface, Agent Sunset & Stream Reliability** -- shipped 2026-04-29
 - ✅ **v0.9.40 Session Lifecycle Reliability** -- shipped 2026-04-25
@@ -15,7 +18,71 @@ Between milestones. v0.9.46 (Site Discoverability — SEO + GEO) shipped 2026-05
 
 ## Phases
 
-_None active — define the next milestone with `/gsd-new-milestone`._
+- [ ] **Phase 217: Move extension files to `extension/`** — Move `background.js`, `manifest.json`, `canvas-interceptor.js`, `content/`, `ui/`, `agents/`, `ws/`, `ai/`, `offscreen/`, `lib/`, `assets/`, `config/` under `extension/`; update manifest paths, importScripts, ui html relative paths, and any cross-package imports; load-test by pointing Chrome at `extension/` as unpacked extension root.
+- [ ] **Phase 218: Rename `mcp-server/` → `mcp/`** — Folder rename only; npm package `fsb-mcp-server` unchanged. Update `mcp/package.json` build script `cp ../extension/ai/tool-definitions.js`; update `npm-publish.yml` `working-directory` from `mcp-server` to `mcp`; update `tests/mcp-version-parity.test.js` and any other test that hardcodes `mcp-server/`.
+- [ ] **Phase 219: Move `server/` → `showcase/server/`** — Move Express + SQLite deploy backend; update `Dockerfile` COPY/CMD paths; update `fly.toml` build artifact; update `deploy.yml` paths-ignore + working-directory.
+- [ ] **Phase 220: READMEs + CI paths + final validation** — Rewrite root `README.md` as repo overview; create per-package READMEs; update `ci.yml` job paths; update `scripts/validate-extension.mjs` to walk `extension/`; update root `package.json` test script paths; final VAL-01..04 (npm pack diff, manual extension UAT, production deploy verification, fresh-clone smoke).
+
+## Phase Details
+
+### Phase 217: Move extension files to `extension/`
+**Goal**: All Chrome-extension source files live under `extension/`; the extension loads cleanly when Chrome is pointed at `extension/` as the unpacked root; no extension-loadable JS file exists at repo root.
+**Depends on**: Nothing (keystone phase — Phase 218 depends on extension/ai/ existing for the tool-definitions copy)
+**Requirements**: EXT-01, EXT-02, EXT-03, EXT-04, EXT-05
+**Success Criteria** (what must be TRUE):
+  1. `git mv` (or equivalent) places `background.js`, `manifest.json`, `canvas-interceptor.js`, `content/`, `ui/`, `agents/`, `ws/`, `ai/`, `offscreen/`, `lib/`, `assets/`, `config/` under `extension/`. Repo root contains no `*.js` extension entry points (excluding root `scripts/`, root tests, etc.).
+  2. `extension/manifest.json` paths are root-relative (e.g., `background.service_worker = "background.js"`); manifest validation (per `scripts/validate-extension.mjs` walking `extension/`) passes with zero errors.
+  3. Loading `extension/` as an unpacked Chrome extension installs cleanly: service worker boots, `importScripts(...)` calls in `background.js` resolve, popup HTML opens, side panel opens, control panel opens. DevTools console shows zero 404s.
+  4. `extension/README.md` exists with: load-as-unpacked instructions, key entry points, link back to root README.
+  5. The smoke automation case (open chrome://newtab → search → glow) runs end-to-end against the relocated extension.
+**Plans**: TBD (planner decomposition)
+
+### Phase 218: Rename `mcp-server/` → `mcp/`
+**Goal**: Folder is renamed; npm package name is unchanged; `mcp/build` produces identical artifacts to pre-rename; CI `mcp-smoke` job passes; `npm-publish.yml` would publish `fsb-mcp-server@<next>` correctly on the next `mcp-v*` tag.
+**Depends on**: Phase 217 (the build script's `cp ../extension/ai/tool-definitions.js` path requires `extension/ai/` to exist).
+**Requirements**: MCP-01, MCP-02, MCP-03, MCP-04, MCP-05
+**Success Criteria**:
+  1. `git mv mcp-server mcp` (and update internal references); `mcp/package.json` name is still `fsb-mcp-server`; version unchanged.
+  2. `npm --prefix mcp run build` exits 0 and produces `mcp/build/index.js` byte-equivalent to the pre-rename build (modulo timestamps).
+  3. `.github/workflows/npm-publish.yml` `defaults.run.working-directory: mcp`; CI dry-run via `gh workflow run npm-publish.yml` (workflow_dispatch) succeeds (no actual publish — just resolves the path).
+  4. `npm run test:mcp-smoke` passes (lifecycle + tools).
+  5. `mcp/README.md` exists.
+**Plans**: TBD
+
+### Phase 219: Move `server/` → `showcase/server/`
+**Goal**: Deploy backend lives under `showcase/`; production deploy works post-merge; fly.io serves `https://full-selfbrowsing.com/` correctly.
+**Depends on**: Nothing (independent of 217/218; can run in parallel but executed sequentially per single-tree convention).
+**Requirements**: SRV-01, SRV-02, SRV-03, SRV-04, SRV-05
+**Success Criteria**:
+  1. `git mv server showcase/server`; internal file structure unchanged.
+  2. `Dockerfile` paths updated; `docker build .` succeeds locally (or in CI dry-run).
+  3. `fly.toml` artifact paths updated; `flyctl deploy --remote-only --config fly.toml` is the same command (no flag changes needed).
+  4. `.github/workflows/deploy.yml` paths-ignore + working-directory updated; workflow triggers on push to main.
+  5. After merge, `curl -A GPTBot https://full-selfbrowsing.com/` returns prerendered HTML (re-verifies SMOKE-01 from v0.9.46).
+**Plans**: TBD
+
+### Phase 220: READMEs + CI paths + final validation
+**Goal**: All four READMEs exist (root + 3 packages); CI workflow paths point at the new layout; root orchestration scripts work; fresh-clone smoke passes.
+**Depends on**: Phases 217, 218, 219
+**Requirements**: DOC-01, DOC-02, DOC-03, DOC-04, CI-01, CI-02, CI-03, CI-04, VAL-01, VAL-02, VAL-03, VAL-04
+**Success Criteria**:
+  1. Four READMEs in place, each scoped to its package; root README is overview-only with links.
+  2. `.github/workflows/ci.yml` job paths updated; `extension`, `mcp-smoke`, `showcase`, `all-green` all pass on the milestone PR.
+  3. `scripts/validate-extension.mjs` walks `extension/`; zero false positives, zero false negatives.
+  4. Root `package.json` test script paths updated; `npm test` from repo root passes.
+  5. `npm pack --dry-run` from `mcp/` produces a tarball whose file list matches `fsb-mcp-server@0.7.4` published tarball (path-stable, no surprise additions/deletions).
+  6. Manual extension UAT: load `extension/` as unpacked, run smoke automation case.
+  7. After merge: production deploy serves correctly; fresh clone of main + `npm install && npm test && npm run validate:extension && npm run test:mcp-smoke && npm run showcase:build` exits 0.
+**Plans**: TBD
+
+## Progress
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 217. Move extension files to `extension/` | 0/0 | Not started | — |
+| 218. Rename `mcp-server/` → `mcp/` | 0/0 | Not started | — |
+| 219. Move `server/` → `showcase/server/` | 0/0 | Not started | — |
+| 220. READMEs + CI paths + final validation | 0/0 | Not started | — |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,13 +1,13 @@
 ---
 gsd_state_version: 1.0
-milestone: null
-milestone_name: between-milestones
-status: complete
+milestone: v0.9.47
+milestone_name: Workspace Reorganization (extension / mcp / showcase)
+status: planning
 last_shipped: v0.9.46
 last_updated: "2026-05-02T00:00:00.000Z"
 last_activity: 2026-05-02
 progress:
-  total_phases: 0
+  total_phases: 4
   completed_phases: 0
   total_plans: 0
   completed_plans: 0


### PR DESCRIPTION
## Summary

Opens milestone **v0.9.47 Workspace Reorganization (extension / mcp / showcase)**.

## Goal

Reorganize the repo into three clearly-bounded top-level packages — \`extension/\`, \`mcp/\`, \`showcase/\` — each owning its own assets, README, and tests. Mechanical reorg only; no functional changes.

## Phases (preliminary)

| Phase | Scope |
|---|---|
| 217 | Move all extension files (\`background.js\`, \`manifest.json\`, \`content/\`, \`ui/\`, \`agents/\`, \`ws/\`, \`ai/\`, \`offscreen/\`, \`lib/\`, \`assets/\`) under \`extension/\` |
| 218 | Rename \`mcp-server/\` → \`mcp/\` (folder rename only; npm package \`fsb-mcp-server\` unchanged) |
| 219 | Move \`server/\` (Express + SQLite deploy backend) → \`showcase/server/\` |
| 220 | READMEs + CI paths + final validation (root README + 3 per-package READMEs; \`ci.yml\` job paths; \`validate-extension.mjs\` walks \`extension/\`; \`npm pack --dry-run\` diff vs published \`fsb-mcp-server@0.7.4\`; manual extension UAT; production deploy verification; fresh-clone smoke) |

## Out of scope

- Angular 19 → 20 migration (next milestone v0.9.48 — A19 EOL 2026-05-19)
- Workspace tooling (npm workspaces / Nx / Turborepo)
- Renaming the npm package \`fsb-mcp-server\`
- Code refactors beyond import-path fixes

## Test plan

- [ ] CI all-green on this PR (planning files only — no code changes)
- [ ] After merge, \`/gsd-plan-phase 217\` to begin execution on the Refinements branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)