### PR TITLE
docs(220): root README repo-layout section + showcase README; final validation (DOC-01..04, CI-01..04, VAL-01..04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,35 @@ FSB ships an [MCP server](#mcp-server) so Claude Code, Cursor, Windsurf, Codex, 
 
 ---
 
+## Repository Layout
+
+This repository is organized into three top level packages, each with its own README:
+
+| Package | Purpose |
+|---------|---------|
+| [`extension/`](./extension/README.md) | Chrome extension (Manifest V3). The AI agent that drives the browser. Load this directory as an unpacked extension. |
+| [`mcp/`](./mcp/README.md) | MCP server (npm: [`fsb-mcp-server`](https://www.npmjs.com/package/fsb-mcp-server)). Lets MCP clients (Claude Desktop, Cursor, Cline, Codex, etc.) drive the same extension. |
+| [`showcase/`](./showcase/README.md) | Marketing site at [full-selfbrowsing.com](https://full-selfbrowsing.com). Angular 19 SSR + Express deploy backend. |
+
+Top level helpers:
+
+- `tests/` — Node test suite covering extension modules, MCP bridge contracts, and lifecycle smoke tests.
+- `scripts/validate-extension.mjs` — static gate that checks `extension/manifest.json` and JS syntax across the extension tree.
+- `.github/workflows/ci.yml` — runs validate, tests, MCP smoke, and showcase build on every PR.
+- `Dockerfile`, `fly.toml` — production deploy of the showcase site (`showcase/server/`) on fly.io.
+
+Run the full local CI gate from the root:
+
+```bash
+npm install
+npm run validate:extension
+npm test
+npm run test:mcp-smoke
+npm --prefix showcase/angular run build
+```
+
+---
+
 ## Screenshots
 
 ### FSB in Action

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -1,0 +1,61 @@
+# FSB Showcase
+
+The marketing site at [full-selfbrowsing.com](https://full-selfbrowsing.com).
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `angular/` | Angular 19 site with SSR and prerender for `/`, `/about`, `/privacy`, `/support`. |
+| `server/` | Express + better-sqlite3 + ws deploy backend (handles dashboard pairing + relay). |
+| `assets/` | Static images, logos, screenshots referenced by the prerendered HTML. |
+| `css/`, `js/`, `*.html` | Legacy static surfaces still served alongside the Angular app (privacy, about, dashboard). |
+| `dist/` | Build output (gitignored). Populated by `angular/` build. |
+
+## Develop
+
+```bash
+cd angular
+npm install
+npm start
+```
+
+The dev server runs at `http://localhost:4200` with hot reload.
+
+## Build
+
+```bash
+npm --prefix angular run build
+```
+
+Runs Angular's SSR + prerender pipeline for the static routes. Output lands in `angular/dist/`.
+
+The `prebuild` lifecycle hook also runs `angular/scripts/build-crawler-files.mjs`, which generates the SEO/GEO surfaces:
+
+- `/robots.txt`
+- `/sitemap.xml`
+- `/llms.txt`
+- `/llms-full.txt`
+
+`Organization` and `SoftwareApplication` JSON-LD blocks are baked into every prerendered HTML page. See `.planning/milestones/v0.9.46-ROADMAP.md` for the SEO/GEO milestone history.
+
+## Deploy
+
+Production runs on fly.io. The repo root `fly.toml` and `Dockerfile` build a container that serves `showcase/server/server.js` (Express + WebSocket relay).
+
+Pushes to `main` trigger `.github/workflows/deploy.yml`, which runs `flyctl deploy --remote-only`. No manual steps required.
+
+## Smoke Test
+
+After deploy, hit production with a crawler user agent to confirm prerender + JSON-LD survived:
+
+```bash
+curl -A GPTBot -sI https://full-selfbrowsing.com/ | head -1
+curl -A GPTBot -s  https://full-selfbrowsing.com/llms.txt | head -5
+```
+
+The npm helper `npm --prefix angular run smoke:crawler` runs the full crawler smoke matrix used in the v0.9.46 UAT.
+
+## Repository Layout
+
+See the root [`README.md`](../README.md) for the full repo overview, including the Chrome extension (`extension/`) and MCP server (`mcp/`).

--- a/showcase/angular/public/llms-full.txt
+++ b/showcase/angular/public/llms-full.txt
@@ -1,4 +1,4 @@
-<!-- generated 2026-04-30 by build-crawler-files.mjs; edit llms-full.source.md -->
+<!-- generated 2026-05-02 by build-crawler-files.mjs; edit llms-full.source.md -->
 # FSB (Full Self-Browsing)
 
 ## 1. Project Description

--- a/showcase/angular/public/sitemap.xml
+++ b/showcase/angular/public/sitemap.xml
@@ -2,18 +2,18 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://full-selfbrowsing.com</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-05-02</lastmod>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/about</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-05-02</lastmod>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/privacy</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-05-02</lastmod>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/support</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-05-02</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Phase 220 — final phase of v0.9.47 milestone.

- **Root \`README.md\`**: added Repository Layout section pointing at \`extension/\`, \`mcp/\`, \`showcase/\` packages. Preserved the existing curated landing-page content (badges, screenshots, deep docs).
- **Created \`showcase/README.md\`**: layout, develop/build/deploy commands, SEO/GEO crawler-file generation overview.
- **Verified (no edits):** \`extension/README.md\` (Phase 217 — references \`mcp/\` and \`showcase/\` correctly); \`mcp/README.md\` (npm-published, no stale folder paths, conservative skip); \`ci.yml\` paths (already correct post-217/218); \`scripts/validate-extension.mjs\` (walks \`extension/\`).
- **Auto-generated by prebuild:** \`showcase/angular/public/{llms-full.txt,sitemap.xml}\` — lastmod refresh.

## Final validation (post-reorg)

| Gate | Result |
|---|---|
| \`npm run validate:extension\` | OK (manifest valid, 230 JS files clean) |
| \`npm test\` | full suite green |
| \`npm run test:mcp-smoke\` | 56/56 PASS |
| \`npm --prefix mcp run build\` | OK |
| \`npm --prefix showcase/angular run build\` | OK (4 routes prerendered) |
| \`curl -A GPTBot https://full-selfbrowsing.com/\` | 200, full SSR payload (~50KB) — production deploy from Phase 219 healthy |

## Deviation (worth noting)

The existing 948-line root \`README.md\` is the public GitHub landing page with curated content. Rather than replace with a lean 3-package overview, I added a Repository Layout section near the top so it points at the packages while preserving the landing page. If you want a lean root + extension/README.md absorbing the bulk, that's a one-shot follow-up.

## Test plan

- [ ] CI all-green on this PR
- [ ] After merge, v0.9.47 is functionally complete \u2014 ready for \`/gsd-complete-milestone v0.9.47\` archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)