### PR TITLE
fix(extension): resolve _lastRemoteControlState identifier collision

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2011,10 +2011,14 @@ var _lastDomStreamStaleFlushCount = 0;
 // 'getRemoteControlState' runtime action. Updated by the
 // 'remoteControlStateChanged' push handler below. SW-lifetime only;
 // null on cold start. Per CONTEXT D-18, disconnected is the safe default.
-// Distinct from ws/ws-client.js:124 _lastRemoteControlState which serves
-// Phase 209 snapshot recovery and remains untouched.
-// ============================================================================
-let _lastRemoteControlState = null;
+// Renamed from _lastRemoteControlState to _bgRemoteControlStateCache to
+// avoid colliding with the same-named identifier in ws/ws-client.js:124.
+// In Chrome service workers, importScripts loads files into the SAME global
+// scope -- two top-level declarations of the same name throw
+// "Identifier '_lastRemoteControlState' has already been declared" and break
+// background.js startup. ws-client.js's cache (Phase 209 snapshot recovery)
+// remains untouched at its original name.
+let _bgRemoteControlStateCache = null;
 
 // Store for AI integration instances per session (for multi-turn conversations)
 // This allows conversation history to persist across iterations within a session
@@ -5090,8 +5094,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       // disconnected-shaped default if no broadcast has happened yet this
       // SW lifetime. Sync tab JS uses this to populate the pill before the
       // first push arrives.
-      const state = (_lastRemoteControlState && typeof _lastRemoteControlState === 'object')
-        ? _lastRemoteControlState
+      const state = (_bgRemoteControlStateCache && typeof _bgRemoteControlStateCache === 'object')
+        ? _bgRemoteControlStateCache
         : { enabled: false, attached: false, tabId: null, reason: 'unknown', ownership: 'none' };
       sendResponse({ success: true, state: state });
       break;
@@ -5103,7 +5107,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       // background.js listens to its own broadcast so the cache survives
       // when the Sync tab is closed.
       if (request.state && typeof request.state === 'object') {
-        _lastRemoteControlState = request.state;
+        _bgRemoteControlStateCache = request.state;
       }
       sendResponse({ success: true });
       break;

--- a/tests/sync-tab-runtime.test.js
+++ b/tests/sync-tab-runtime.test.js
@@ -38,8 +38,8 @@ const WS = read(path.join('extension', 'ws', 'ws-client.js'));
 console.log('\n--- Phase 213 SYNC-02: background.js runtime contracts ---');
 
 assert(
-  BG.includes('let _lastRemoteControlState = null'),
-  '[D-18] background.js declares module-scope `let _lastRemoteControlState = null`'
+  BG.includes('let _bgRemoteControlStateCache = null'),
+  '[D-18] background.js declares module-scope `let _bgRemoteControlStateCache = null` (renamed to avoid colliding with ws-client.js _lastRemoteControlState in service-worker global scope)'
 );
 
 assert(
@@ -58,7 +58,7 @@ assert(
 );
 
 assert(
-  BG.includes('_lastRemoteControlState = request.state'),
+  BG.includes('_bgRemoteControlStateCache = request.state'),
   '[D-18] cache updates from request.state on every push'
 );
 


### PR DESCRIPTION
## Summary

Pre-existing bug in the extension surfaced when loading \`extension/\` as unpacked Chrome extension: service worker fails background.js startup with

\`\`\`
Identifier '_lastRemoteControlState' has already been declared
\`\`\`

Both \`extension/background.js\` (Phase 213 D-18) and \`extension/ws/ws-client.js\` (Phase 209) declare a top-level \`_lastRemoteControlState\`. The Phase 213 author marked them as "distinct" but Chrome service workers run \`importScripts\` in the SAME global scope, so two top-level declarations of the same name throw.

This wasn't caught earlier because:
- Tests grep source files (don't execute the service worker)
- The bug manifests only at extension load time in Chrome
- It existed before the v0.9.47 reorg; the user surfaced it loading the relocated extension/

## Fix

Rename the background.js-side identifier to \`_bgRemoteControlStateCache\`. ws-client.js's older Phase 209 cache keeps its name (source of truth for snapshot recovery).

Updated \`tests/sync-tab-runtime.test.js\` asserts to match the new identifier.

## Test plan

- [ ] CI all-green
- [ ] After merge, manual extension reload — service worker boots cleanly, no \`already been declared\` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)