### PR TITLE
docs: refresh package readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,28 @@
-# FSB v0.9.45rc1 Full Self Browsing
+# FSB v0.9.50 Full Self Browsing
 
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/fsb_logo_dark.png" />
-  <source media="(prefers-color-scheme: light)" srcset="assets/fsb_logo_light.png" />
-  <img src="assets/fsb_logo_light.png" alt="FSB Full Self Browsing" width="200" />
+  <source media="(prefers-color-scheme: dark)" srcset="extension/assets/fsb_logo_dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="extension/assets/fsb_logo_light.png" />
+  <img src="extension/assets/fsb_logo_light.png" alt="FSB Full Self Browsing" width="200" />
 </picture>
 
-<!-- Row 1: Identity badges -->
 ![FSB](https://img.shields.io/badge/FSB-Full_Self_Browsing-000000?style=for-the-badge)
-![Version](https://img.shields.io/badge/version-0.9.45rc1-0078D4?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-0.9.50-0078D4?style=for-the-badge)
 ![Manifest V3](https://img.shields.io/badge/Manifest_V3-Chrome-34A853?style=for-the-badge&logo=googlechrome&logoColor=white)
 ![License](https://img.shields.io/badge/license-BSL_1.1-F5C518?style=for-the-badge)
 
-<!-- Row 2: Dynamic GitHub stats -->
 ![Stars](https://img.shields.io/github/stars/LakshmanTurlapati/FSB?style=flat-square&logo=github&label=Stars)
 ![Forks](https://img.shields.io/github/forks/LakshmanTurlapati/FSB?style=flat-square&logo=github&label=Forks)
 ![Issues](https://img.shields.io/github/issues/LakshmanTurlapati/FSB?style=flat-square&logo=github&label=Issues)
 ![Last Commit](https://img.shields.io/github/last-commit/LakshmanTurlapati/FSB?style=flat-square&logo=github&label=Last%20Commit)
-![Repo Size](https://img.shields.io/github/repo-size/LakshmanTurlapati/FSB?style=flat-square&logo=github&label=Repo%20Size)
-
-<!-- Row 3: Project stats + provider brands -->
-![AI Models](https://img.shields.io/badge/AI_Models-21-8B5CF6?style=flat-square)
-![Browser Actions](https://img.shields.io/badge/Browser_Actions-47-F97316?style=flat-square)
-![Site Guides](https://img.shields.io/badge/Site_Guides-9_Categories-22C55E?style=flat-square)
-![xAI](https://img.shields.io/badge/xAI-Grok-000000?style=flat-square&logo=x&logoColor=white)
-![OpenAI](https://img.shields.io/badge/OpenAI-GPT-412991?style=flat-square&logo=openai&logoColor=white)
-![Anthropic](https://img.shields.io/badge/Anthropic-Claude-D4A574?style=flat-square&logo=anthropic&logoColor=white)
-![Gemini](https://img.shields.io/badge/Google-Gemini-4285F4?style=flat-square&logo=googlegemini&logoColor=white)
 
 **AI powered browser automation through natural language. Tell it what to do, and watch it browse for you.**
 
 *Pure structural intelligence. Zero vision. Zero guessing.*
 
-[Quick Start](#quick-start) · [MCP Server](#mcp-server) · [Architecture](#architecture-overview) · [AI Providers](#multi-model-ai-integration) · [Memory](#long-term-memory-system) · [Contributing](#contributing)
+[Quick Start](#quick-start) · [MCP Server](#mcp-server) · [Architecture](#architecture) · [Providers](#ai-providers) · [Development](#development)
 
 </div>
 
@@ -42,130 +30,116 @@
 
 ## Overview
 
-> **Note**: FSB v0.9.45rc1 is production ready and fully functional, but browser automation can behave unpredictably on complex sites. Always monitor automation actions and test on non critical pages first. Feedback and contributions are welcome.
+FSB (Full Self Browsing) is an open source Chrome extension for AI powered browser automation. Describe a task in plain English; FSB reads the live DOM, builds a plan, executes browser actions, verifies results, and reports progress through the popup, side panel, or MCP.
 
-FSB (Full Self Browsing) is an open source Chrome extension that brings AI powered browser automation to your fingertips. Describe what you want in plain English, and FSB analyzes the page, plans the actions, and executes them. Pick from **four AI providers** (xAI Grok, OpenAI GPT, Anthropic Claude, Google Gemini) across 21 models.
+> FSB v0.9.50 is functional and production ready for supervised automation. Browser automation can still behave unpredictably on complex or sensitive sites, so monitor actions and test on non critical pages first.
 
-### Better Than Vision Based Agents
+### Why DOM First
 
-Project Mariner, Claude Computer Use, OpenAI Operator. They all rely on vision to understand the page. **FSB reads the actual DOM.** No screenshots. No guessing.
+Project Mariner, Claude Computer Use, and OpenAI Operator rely heavily on visual page understanding. FSB uses page structure directly.
 
-| Metric | Vision agents | FSB |
-|--------|---------------|-----|
-| Per step latency | 1 to 3 seconds | 50 to 200 ms |
-| Cost per 100 steps | ~$0.18 | ~$0.03 |
-| Hidden elements | No | Yes |
+| Metric | Vision based agents | FSB |
+|--------|---------------------|-----|
+| Page understanding | Screenshots | DOM, selectors, ARIA, forms |
+| Hidden elements | Often invisible | Available in structure |
+| Typical per step latency | 1 to 3 seconds | 50 to 200 ms |
+| Token/cost profile | Image heavy | Text/structure heavy |
 
-### Use With Your Favorite AI Client
+### What It Does
 
-FSB ships an [MCP server](#mcp-server) so Claude Code, Cursor, Windsurf, Codex, VS Code, and any MCP capable client can drive your browser directly. The intelligence of any AI combined with the precision of FSB's DOM engine.
+- Runs natural language browser tasks from the popup or side panel.
+- Supports xAI, Gemini, OpenAI, Anthropic, OpenRouter, LM Studio, and custom OpenAI-compatible endpoints.
+- Discovers live provider model lists and falls back to bundled defaults.
+- Uses 50 canonical automation tools in the extension engine and 59 MCP tools for external clients.
+- Provides DOM snapshots, action verification, smart waiting, stuck detection, visual feedback, and session logs.
+- Maintains long term memory for past sites, workflows, selectors, and task outcomes.
+- Includes secure credential and payment vault flows for supervised autofill.
+- Exposes a local MCP server so Claude Code, Codex, Cursor, VS Code, Windsurf, and other MCP clients can drive the browser.
 
-<details>
-<summary><b>All features (detailed list)</b></summary>
+Background agents are retired. Existing `chrome.storage.local['bgAgents']` data is preserved for users who had old agents, but scheduled or recurring automation is no longer an active FSB feature.
 
-- **Multi Model AI Support**: Four fully integrated providers across 21 models
-- **Universal Provider Architecture**: Model agnostic engine for any OpenAI compatible API, with automatic parameter discovery and self healing
-- **Natural Language Interface**: Describe tasks in plain English, no scripting
-- **Smart DOM Analysis**: Webpage structure analysis with incremental diffing and element identification
-- **Comprehensive Action Library**: 47 browser actions including click, type, scroll, navigate, multi tab control, and form handling
-- **Site Specific Intelligence**: Domain guides for ecommerce, finance, social media, travel, coding, email, career, gaming, and productivity
-- **Long Term Memory**: Episodic, semantic, and procedural memory with AI enriched extraction and consolidation across sessions
-- **Background Agents**: Scheduled automation tasks with chrome.alarms, run history, and session replay
-- **Site Visualization**: Per site D3.js mind maps and a consolidated 3D knowledge graph of all guide categories
-- **Cross Site Pattern Analysis**: AI powered detection of recurring UI patterns across websites
-- **Dual Cost Tracking**: Separate cost monitoring for automation sessions and memory operations
-- **Visual Feedback**: Viewport glow indicators, element highlights, and progress overlay with step counting
-- **Smart DOM Waiting**: Event driven waiting based on DOM mutations and loading state, not fixed delays
-- **Markdown and Diagram Rendering**: Rich chat output with mermaid diagrams and Chart.js charts
-- **Action Verification**: Post action state validation to confirm actions had their intended effect
-- **Multi Tab Support**: Open, close, switch, and list browser tabs during automation
-- **Dark Theme**: Full dark mode across popup, side panel, and options
-- **Analytics and Monitoring**: Usage tracking, token counting, and cost calculation per model
-- **CAPTCHA Integration**: Built in framework for CAPTCHA solving services
-- **Secure Configuration**: AES-GCM encrypted API key storage
-- **Smart Recovery**: Automatic stuck detection with DOM hashing and adaptive behavior
-- **Multiple UI Modes**: Popup chat and persistent side panel
+### Common Use Cases
 
-</details>
+- **QA and regression checks**: repeat page flows, click through states, fill forms, and collect action logs.
+- **Research**: navigate pages, extract visible information, and summarize results without relying on screenshots.
+- **Data entry**: move through structured forms with validation, dropdowns, custom controls, and table inputs.
+- **Ecommerce**: compare product pages, inspect prices, monitor availability manually, and prepare carts under supervision.
+- **Finance and dashboards**: read charts, tables, and current page state when a human remains in control.
+- **Developer workflows**: drive GitHub, issue trackers, documentation sites, coding platforms, and browser-based tools.
+- **Accessibility and DOM inspection**: expose structure, labels, selectors, forms, and hidden controls for debugging.
 
-### Use Cases
+FSB is most reliable when the task can be expressed as page structure and user actions. It is intentionally not a stealth browser, scraper farm, or unsupervised account operator.
 
-- **Web Testing**: Automate repetitive QA workflows
-- **Data Entry**: Fill forms across multiple sites
-- **Research**: Navigate and extract information from pages
-- **Ecommerce**: Product research and comparison shopping
-- **Finance**: Stock lookups, portfolio monitoring, financial data gathering
-- **Development**: GitHub workflows, code review navigation, coding platforms
-- **Productivity**: Streamline routine browsing tasks
-- **Background Monitoring**: Schedule recurring agents to track prices or changes
+### Feature Detail
 
-> **Tip**: Start with simple tasks to build familiarity, and watch what FSB does. Your feedback helps improve accuracy.
+| Area | Current behavior |
+|------|------------------|
+| DOM analysis | Captures visible and structural page data, element refs, selectors, forms, ARIA labels, and DOM deltas. |
+| Action execution | Supports clicks, typing, keys, scrolling, navigation, tabs, spreadsheet ranges, coordinate tools, and direct JavaScript. |
+| Verification | Checks post-action state, loading behavior, DOM stability, and stuck-action repetition. |
+| UI surfaces | Popup chat, persistent side panel, options/control panel, logs, analytics, memory, vault, and sync controls. |
+| Model support | Hosted providers, OpenRouter routing, LM Studio local models, custom endpoints, and live model discovery. |
+| Output rendering | Markdown, sanitized HTML, Mermaid diagrams, Chart.js charts, and task progress messages. |
+| Observability | Session history, action logs, token/cost accounting, diagnostics ring buffer, and MCP status probes. |
+| Security | Encrypted keys, vault unlock flows, redaction helpers, DOMPurify, and restricted-tab recovery messaging. |
+
+The core design goal is to keep the browser as the source of truth. The model receives structured page context, makes a tool decision, and the extension verifies what changed before moving to the next step.
 
 ---
 
 ## Repository Layout
 
-This repository is organized into three top level packages, each with its own README:
+| Path | Purpose |
+|------|---------|
+| [`extension/`](./extension/README.md) | Chrome extension package. Load this directory as an unpacked MV3 extension. |
+| [`mcp/`](./mcp/README.md) | npm package `fsb-mcp-server`, the local MCP bridge for external AI clients. |
+| [`showcase/`](./showcase/README.md) | Marketing and dashboard site for full-selfbrowsing.com. Angular 20 static prerender + Express relay. |
+| `showcase/server/` | Node/Express deploy backend for pairing, relay, auth, and dashboard data. |
+| `server-py/` | Legacy Python/FastAPI-style backend prototype retained for reference. |
+| `tests/` | Node tests for extension modules, MCP contracts, bridge behavior, and regression coverage. |
+| `scripts/` | Repo maintenance and validation scripts. |
 
-| Package | Purpose |
-|---------|---------|
-| [`extension/`](./extension/README.md) | Chrome extension (Manifest V3). The AI agent that drives the browser. Load this directory as an unpacked extension. |
-| [`mcp/`](./mcp/README.md) | MCP server (npm: [`fsb-mcp-server`](https://www.npmjs.com/package/fsb-mcp-server)). Lets MCP clients (Claude Desktop, Cursor, Cline, Codex, etc.) drive the same extension. |
-| [`showcase/`](./showcase/README.md) | Marketing site at [full-selfbrowsing.com](https://full-selfbrowsing.com). Angular 19 SSR + Express deploy backend. |
+Top level deploy and validation files:
 
-Top level helpers:
-
-- `tests/` — Node test suite covering extension modules, MCP bridge contracts, and lifecycle smoke tests.
-- `scripts/validate-extension.mjs` — static gate that checks `extension/manifest.json` and JS syntax across the extension tree.
-- `.github/workflows/ci.yml` — runs validate, tests, MCP smoke, and showcase build on every PR.
-- `Dockerfile`, `fly.toml` — production deploy of the showcase site (`showcase/server/`) on fly.io.
-
-Run the full local CI gate from the root:
-
-```bash
-npm install
-npm run validate:extension
-npm test
-npm run test:mcp-smoke
-npm --prefix showcase/angular run build
-```
+- `package.json` - root commands for validation, tests, packaging, and showcase helpers.
+- `Dockerfile`, `fly.toml` - production deploy for the showcase server on fly.io.
+- `.github/workflows/ci.yml` - validates extension, MCP smoke tests, and showcase build.
+- `.github/workflows/deploy.yml` - deploys the production site on `main` pushes.
 
 ---
 
 ## Screenshots
 
-### FSB in Action
-
 <table>
 <tr>
 <td width="50%" align="center">
-<img src="assets/screenshots/demo-task-input.png" alt="FSB side panel on YouTube, user entering a task" width="100%" />
+<img src="extension/assets/screenshots/demo-task-input.png" alt="FSB side panel on YouTube, user entering a task" width="100%" />
 <br/><sub><b>Task Input</b></sub>
 </td>
 <td width="50%" align="center">
-<img src="assets/screenshots/demo-task-result.png" alt="FSB automating YouTube search, typing Sunflower" width="100%" />
+<img src="extension/assets/screenshots/demo-task-result.png" alt="FSB automating YouTube search, typing Sunflower" width="100%" />
 <br/><sub><b>Task Execution</b></sub>
 </td>
 </tr>
 </table>
 
 <details>
-<summary><strong>View more screenshots</strong></summary>
+<summary><strong>More screenshots</strong></summary>
 
 #### Dashboard and Analytics
-<img src="assets/screenshots/dashboard-analytics.png" alt="Options dashboard showing token usage charts and cost breakdown by model" width="100%" />
+<img src="extension/assets/screenshots/dashboard-analytics.png" alt="Options dashboard showing token usage charts and cost breakdown by model" width="100%" />
 
 #### API Configuration
-<img src="assets/screenshots/api-configuration.png" alt="API configuration panel with provider selection and key entry" width="100%" />
+<img src="extension/assets/screenshots/api-configuration.png" alt="API configuration panel with provider selection and key entry" width="100%" />
 
 #### Passwords Manager
-<img src="assets/screenshots/passwords-manager.png" alt="Passwords manager for storing site credentials used during automation" width="100%" />
+<img src="extension/assets/screenshots/passwords-manager.png" alt="Passwords manager for storing site credentials used during automation" width="100%" />
 
 #### Memory and Site Explorer
-<img src="assets/screenshots/memory-site-explorer.png" alt="Memory viewer and site explorer showing crawled site structure" width="100%" />
+<img src="extension/assets/screenshots/memory-site-explorer.png" alt="Memory viewer and site explorer showing crawled site structure" width="100%" />
 
 #### Intelligence Knowledge Graph
-<img src="assets/screenshots/intelligence-graph.png" alt="3D knowledge graph visualizing site guide categories and supported domains" width="100%" />
+<img src="extension/assets/screenshots/intelligence-graph.png" alt="3D knowledge graph visualizing site guide categories and supported domains" width="100%" />
 
 </details>
 
@@ -173,805 +147,431 @@ npm --prefix showcase/angular run build
 
 ## Quick Start
 
-> Get running in under two minutes. Clone, load in Chrome, configure one API key, and start automating.
-
 ### Prerequisites
 
-- Google Chrome 88+ or any Chromium based browser (Edge, Brave, etc.)
-- **One API key** from any supported provider (only one is required):
-  - xAI Grok ([Get one here](https://x.ai/api)), recommended for automation
-  - OpenAI ([Get one here](https://platform.openai.com/api-keys))
-  - Anthropic ([Get one here](https://console.anthropic.com/))
-  - Google Gemini ([Get one here](https://ai.google.dev/)), includes a FREE tier (Gemini 2.0 Flash)
+- Chrome 88+ or another Chromium based browser such as Edge or Brave.
+- One AI provider setup:
+  - xAI API key: https://x.ai/api
+  - Gemini API key: https://aistudio.google.com/app/apikey
+  - OpenAI API key: https://platform.openai.com/api-keys
+  - Anthropic API key: https://console.anthropic.com/account/keys
+  - OpenRouter API key: https://openrouter.ai/keys
+  - LM Studio local server running at `http://localhost:1234`
+  - A custom OpenAI-compatible chat completions endpoint
 
-### Installation
+### Install The Extension
 
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/lakshmanturlapati/FSB.git
-   cd FSB
-   ```
+```bash
+git clone https://github.com/lakshmanturlapati/FSB.git
+cd FSB
+```
 
-2. **Load the extension in Chrome**
-   - Open `chrome://extensions/`
-   - Enable "Developer mode" (top right)
-   - Click "Load unpacked"
-   - Select the FSB directory
+1. Open `chrome://extensions/`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked**.
+4. Select the `extension/` directory.
+5. Click the FSB toolbar icon, open settings, configure a provider, and test the API connection.
 
-3. **Start automating**
-   - Click the FSB extension icon
-   - Configure your preferred AI model and API key in settings
-   - Enter a task like "Search for cats on Google"
-   - Watch FSB work
+Start with simple tasks such as:
 
-### First Steps
+- `Scroll down`
+- `Search for cats on Google`
+- `Click the first search result`
+- `Read this page and summarize it`
 
-1. **Configure your AI model**: Open settings and pick Grok, GPT, Claude, or Gemini
-2. **Test the connection**: Use the "Test API" button to verify the chosen model works
-3. **Start simple**: Try basic tasks like "scroll down" or "click the search button"
-4. **Monitor actions**: Visual feedback shows each step
-5. **Explore features**: Try side panel mode for persistent access while browsing
-6. **Share feedback**: Report issues or ideas to help improve FSB
+Reload the extension from `chrome://extensions/` after local code changes. Reload open tabs after the extension reloads so content scripts re-inject.
+
+### First Run Checklist
+
+1. Open the FSB control panel from the extension.
+2. Select a provider and model.
+3. Enter the matching API key or local endpoint.
+4. Use **Test API** to confirm the model can answer.
+5. Open a normal webpage, not a browser-internal page.
+6. Try a read-only task first, then a simple click or type task.
+7. Keep the visual overlay enabled while evaluating behavior.
+
+If a site uses heavy client rendering, custom canvas controls, or unusual shadow DOM, start by asking FSB to read the page and identify available controls. That gives the model a better first snapshot and makes failures easier to debug.
+
+### Quick Troubleshooting
+
+| Problem | Check |
+|---------|-------|
+| Extension does not appear | Confirm Chrome loaded `extension/`, not the repo root. |
+| API test fails | Confirm the selected provider, key, endpoint, and model belong together. |
+| Page reads fail | Move away from browser-internal pages such as `chrome://` or extension pages. |
+| Clicks miss targets | Refresh the DOM snapshot, scroll the target into view, or use coordinate tools. |
+| Typed text does not stick | Prefer `type_text` over JavaScript value assignment on controlled inputs. |
+| MCP tools are missing | Restart the host client and run `fsb-mcp-server doctor`. |
+| MCP tools time out | Check `status --watch`, active tab readiness, and whether another task is queued. |
+
+Most failures are recoverable by inspecting the current page, refreshing selectors, or restarting the local MCP bridge. Reinstalling the MCP config should be the last step, not the first.
+
+### Local Development Setup
+
+You do not need a build step to load the extension in Chrome. You only need npm dependencies when running tests, building MCP, or building the showcase site.
+
+```bash
+npm install
+npm --prefix mcp install
+npm --prefix showcase/angular install
+```
+
+The extension reads bundled scripts directly from `extension/`. The MCP package is TypeScript and must be built before smoke tests or npm publishing. The showcase is a normal Angular app with static prerender output served by the production Express backend.
 
 ---
 
 ## MCP Server
 
-FSB ships a standalone MCP server ([`fsb-mcp-server`](https://www.npmjs.com/package/fsb-mcp-server)) that connects any MCP capable AI client to your browser. **62 tools** across manual control, visual sessions, autopilot, vault, agents, and observability.
+FSB ships [`fsb-mcp-server`](https://www.npmjs.com/package/fsb-mcp-server), a local MCP server that lets external AI clients control the same browser extension. It exposes 59 tools across visual sessions, manual browser control, read-only page inspection, autopilot, vault, and observability.
 
-> **Full setup, tool reference, transport options, and architecture live in [mcp/README.md](mcp/README.md).**
+The extension connects to the MCP bridge on:
+
+```text
+ws://localhost:7225
+```
+
+Optional Streamable HTTP mode exposes:
+
+```text
+http://127.0.0.1:7226/mcp
+```
 
 ### One Command Install
 
 ```bash
-npx -y fsb-mcp-server install --claude-desktop   # Claude Desktop
-npx -y fsb-mcp-server install --claude-code      # Claude Code
-npx -y fsb-mcp-server install --cursor           # Cursor
-npx -y fsb-mcp-server install --vscode           # VS Code
-npx -y fsb-mcp-server install --windsurf         # Windsurf
-npx -y fsb-mcp-server install --cline            # Cline
-npx -y fsb-mcp-server install --zed              # Zed
-npx -y fsb-mcp-server install --gemini           # Gemini CLI
-npx -y fsb-mcp-server install --codex            # OpenAI Codex
-npx -y fsb-mcp-server install --continue         # Continue
-npx -y fsb-mcp-server install --all              # All detected platforms
+npx -y fsb-mcp-server install --claude-desktop
+npx -y fsb-mcp-server install --claude-code
+npx -y fsb-mcp-server install --cursor
+npx -y fsb-mcp-server install --vscode
+npx -y fsb-mcp-server install --windsurf
+npx -y fsb-mcp-server install --codex
+npx -y fsb-mcp-server install --all
 ```
 
-Preview without writing: `npx -y fsb-mcp-server install --all --dry-run`
-Remove from a platform: `npx -y fsb-mcp-server uninstall --cursor`
+Preview without writing:
 
-### Manual Setup Examples
+```bash
+npx -y fsb-mcp-server install --all --dry-run
+npx -y fsb-mcp-server install --list
+```
 
-**Claude Code**
+### Manual Examples
+
+Claude Code:
+
 ```bash
 claude mcp add --scope user fsb -- npx -y fsb-mcp-server
 ```
 
-**Codex** (`~/.codex/config.toml`)
+Codex (`~/.codex/config.toml`):
+
 ```toml
 [mcp_servers.fsb]
 command = "npx"
 args = ["-y", "fsb-mcp-server"]
 ```
 
-**VS Code / Cursor / Windsurf** (`mcp.json` or equivalent)
+VS Code (`mcp.json`):
+
 ```json
 {
-  "mcpServers": {
-    "fsb": { "command": "npx", "args": ["-y", "fsb-mcp-server"] }
+  "servers": {
+    "fsb": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "fsb-mcp-server"]
+    }
   }
 }
 ```
 
-For OpenCode, OpenClaw, parity notes, visual session lifecycle, transport options (stdio or local Streamable HTTP), and the full 62 tool reference, see [mcp/README.md](mcp/README.md).
+Diagnostics:
 
-If MCP stops working, run `npm run test:mcp-smoke` first, then `npx -y fsb-mcp-server doctor`, then `npx -y fsb-mcp-server status --watch`. Only fall back to manual reinstall when the reported layer points there.
+```bash
+npx -y fsb-mcp-server doctor
+npx -y fsb-mcp-server status --watch
+npx -y fsb-mcp-server wait-for-extension
+```
+
+See [mcp/README.md](mcp/README.md) for the full tool reference and client-specific setup notes.
+
+OpenCode and OpenClaw are supported through manual or unsupported fallback setup paths; after editing host configuration, refresh or reload the client if FSB tools do not appear.
+
+### MCP Usage Guidance
+
+Manual tools are the default path for most external clients. They let the caller inspect the page, pick a selector, act, and verify. `run_task` is useful when the user explicitly wants FSB to run its own automation loop, but manual control is easier to audit and recover.
+
+Recommended manual pattern:
+
+1. `start_visual_session` so the browser shows the trusted client badge.
+2. `read_page` or `get_dom_snapshot` to understand the current page.
+3. Use `execute_js` for safe DOM reads and simple DOM-triggered clicks.
+4. Use native tools such as `click`, `type_text`, `press_key`, and `drag` when real browser events matter.
+5. Verify with `read_page`, `get_page_snapshot`, or `get_dom_snapshot`.
+6. `end_visual_session` when done.
+
+Use `doctor` and `status --watch` before changing client configs. Most MCP failures are connection, extension wake, active-tab, or content-script readiness issues, not install problems.
 
 ---
 
-## Documentation
-
-### Architecture Overview
-
-FSB follows a modular architecture designed for reliability and extensibility:
+## Architecture
 
 ```mermaid
 graph TB
-    subgraph UI["UI Layer"]
-        P["Popup Chat"]
-        SP["Side Panel"]
-        OPT["Options Dashboard"]
-    end
-
-    subgraph Core["Core Engine"]
-        BG["Background Worker<br/>Session Orchestration"]
-        CFG["Config Manager<br/>AES-GCM Encryption"]
-        AN["Analytics<br/>Dual Cost Tracking"]
-    end
-
-    subgraph Intelligence["Intelligence Layer"]
-        UP["Universal Provider<br/>21 Models, 4 Providers"]
-        AI["AI Integration<br/>Prompt Engineering"]
-        SG["Site Guides<br/>9 Domain Categories"]
-        MEM["Memory System<br/>Episodic / Semantic / Procedural"]
-        XP["Cross-Site Patterns<br/>UI Pattern Detection"]
-        VIZ["Visualization<br/>D3.js + 3D Canvas"]
-        AGT["Background Agents<br/>Scheduled Tasks"]
-    end
-
-    subgraph Content["Content Scripts"]
-        DOM["DOM Analysis<br/>Incremental Diffing"]
-        ACT["Actions Engine<br/>47 Browser Actions"]
-        SEL["Selector Generator<br/>Multi-Strategy CSS"]
-        VF["Visual Feedback<br/>Glow + Highlights"]
-        AV["Action Verification<br/>State Validation"]
-    end
-
-    subgraph External["External Services"]
-        XAI["xAI Grok API"]
-        OAI["OpenAI GPT API"]
-        ANT["Anthropic Claude API"]
-        GEM["Google Gemini API"]
-        SRV["Server Backends<br/>Node.js / Python"]
-    end
-
-    UI --> Core
-    Core --> Intelligence
-    Core --> Content
-    Intelligence --> External
-    AGT --> SRV
-    Content --> |"Web Page<br/>Automated Interactions"| ACT
-
+    UI["Popup / Side Panel / Options"] --> BG["MV3 Background Worker"]
+    BG --> AI["Universal Provider"]
+    BG --> CS["Content Scripts"]
+    BG --> MEM["Memory + Analytics"]
+    BG --> MCP["MCP Bridge"]
+    AI --> APIs["xAI / Gemini / OpenAI / Anthropic / OpenRouter / Local"]
+    CS --> PAGE["Web Page DOM"]
+    MCP --> CLIENTS["Claude Code / Codex / Cursor / VS Code / Others"]
 ```
 
-**Architecture Components:**
+### Main Runtime Pieces
 
-**User Interface Layer**
-- **Popup Chat**: Quick task execution with compact chat UI and markdown rendering
-- **Side Panel**: Persistent automation sessions visible while browsing
-- **Options Dashboard**: Configuration, analytics, memory viewer, session history, and log viewer
+- **Background worker** (`extension/background.js`): owns sessions, model calls, tool execution, MCP routing, and storage orchestration.
+- **Content scripts** (`extension/content/`): analyze the DOM, create element references, execute actions, stream DOM state, wait for stable state, and render visual feedback.
+- **AI layer** (`extension/ai/`): universal OpenAI-compatible request engine, provider settings, model discovery, tool definitions, transcripts, and action history.
+- **Memory** (`extension/lib/memory/`): stores episodic, semantic, and procedural records, then retrieves relevant prior context for later tasks.
+- **Visualization** (`extension/lib/visualization/`): D3/site graph views for guide and memory exploration.
+- **Vault** (`extension/config/secure-config.js` plus UI flows): encrypts API keys and saved user data in Chrome storage.
+- **MCP package** (`mcp/`): TypeScript server that translates MCP calls into extension bridge messages.
 
-**Background Service Worker**
-- **Session Management**: Orchestrates automation workflows and maintains state
-- **Universal Provider**: Model agnostic AI communication with automatic parameter discovery
-- **Configuration Manager**: AES-GCM encrypted settings storage
-- **Analytics Tracking**: Usage, performance, and cost calculations per model
-- **Site Guide Loader**: Matches the current domain to specialized guides across 9 categories
+### Automation Flow
 
-**Content Script Layer (10 modular files)**
-- **DOM Analysis** (`dom-analysis.js`, `dom-state.js`): Page structure parsing with incremental diffing
-- **Action Execution** (`actions.js`): 47 browser actions with smart delays and error handling
-- **Selector Generation** (`selectors.js`): Multiple CSS selector strategies for reliability
-- **Action Verification** (`utils/action-verification.js`): Post action state validation
-- **Visual Feedback** (`visual-feedback.js`): Viewport glow, element highlights, and progress overlay
-- **Accessibility, Messaging, Lifecycle**: ARIA helpers, background communication, init/cleanup guards
+1. User or MCP client submits a task.
+2. FSB captures the active page structure.
+3. Relevant site guides and memory are retrieved.
+4. The selected model plans the next tool call.
+5. Content scripts execute browser actions and wait for visible change.
+6. FSB verifies the result, records analytics, and either continues or finishes.
 
-**Memory and Intelligence Layer**
-- **Memory Manager** (`lib/memory/memory-manager.js`): Lifecycle orchestration for creation, retrieval, consolidation, and cleanup
-- **Memory Extractor** (`lib/memory/memory-extractor.js`): AI enriched extraction of episodic, semantic, and procedural memories
-- **Memory Consolidator** (`lib/memory/memory-consolidator.js`): Deduplication and merging over time
-- **Cross Site Patterns** (`lib/memory/cross-site-patterns.js`): Detects recurring login flows, navigation, and form layouts across sites
-- **Site Visualization** (`lib/visualization/site-graph.js`): D3.js force directed per site mind maps
-- **Knowledge Graph** (`lib/visualization/knowledge-graph.js`): 3D Canvas consolidated view of all 9 site guide categories
-- **Sitemap Processing** (`sitemap-converter.js`, `sitemap-refiner.js`): Sitemaps to structured memory entries
+### State And Data Flow
 
-**Background Agent Layer**
-- **Agent Manager** (`agents/agent-manager.js`): Lifecycle for scheduled agents
-- **Agent Scheduler** (`agents/agent-scheduler.js`): chrome.alarms based scheduling
-- **Agent Executor** (`agents/agent-executor.js`): Runs tasks with session replay and result capture
-- **Server Sync** (`agents/server-sync.js`): Optional sync with Node.js or Python backends
+FSB stores configuration and runtime data in Chrome storage. API keys and saved sensitive values go through the secure configuration layer. Session logs, analytics, and memory records are kept locally unless a user explicitly enables server sync or uses the showcase dashboard pairing flow.
 
-**External Services**
-- **AI APIs**: xAI Grok, OpenAI GPT, Anthropic Claude, Google Gemini
-- **CAPTCHA Services**: Optional integration for automated solving
-- **Server Backends**: Optional Node.js (`showcase/server/`) and Python/Flask (`server-py/`) for agent persistence
+During a task, the background worker owns the session state and talks to three main collaborators:
 
-### Core Components
+- content scripts for page reads and browser actions
+- the selected provider for planning and response generation
+- local storage for config, analytics, memory, and logs
 
-<details>
-<summary><b>View core component file map</b></summary>
+The MCP server does not replace the extension runtime. It is a local bridge that translates MCP requests into the same background-worker routes used by FSB's own UI.
 
-| Path | Description |
-|------|-------------|
-| `background.js` | Service worker, session orchestration, AI communication |
-| `ai/ai-integration.js` | Prompt engineering, task type detection, response parsing |
-| `ai/universal-provider.js` | Model agnostic AI provider with automatic parameter discovery |
-| `ai/ai-providers.js` | Provider configurations and model registry |
-| `config/config.js` | Configuration management with model validation |
-| `config/secure-config.js` | AES-GCM encrypted API key storage |
-| `config/init-config.js` | First run setup and configuration migration |
-| `content/` | 10 modular content script files |
-| `content/actions.js` | 47 browser action tools |
-| `content/dom-analysis.js` | DOM traversal and element extraction |
-| `content/visual-feedback.js` | Viewport glow, element highlights, progress overlay |
-| `lib/memory/` | Long term memory system (9 modules) |
-| `lib/visualization/site-graph.js` | D3.js force directed per site visualization |
-| `lib/visualization/knowledge-graph.js` | 3D Canvas consolidated knowledge graph |
-| `agents/` | Background agent system (4 modules) |
-| `utils/analytics.js` | Usage tracking, token counting, cost calculation |
-| `utils/automation-logger.js` | Structured logging with session recording |
-| `utils/action-verification.js` | Post action state validation |
-| `utils/dom-state-manager.js` | Incremental DOM diffing |
-| `utils/keyboard-emulator.js` | Chrome DevTools Protocol key emulation |
-| `utils/site-explorer.js` | Automated website reconnaissance via BFS crawling |
-| `site-guides/` | Domain specific automation intelligence (9 categories) |
-| `site-maps/` | Generated site structure maps (JSON) |
-| `ui/` | Popup, side panel, options, markdown renderer |
-| `showcase/server/` | Optional Node.js backend for agent data |
-| `server-py/` | Optional Python/Flask backend for agent data |
+### Browser Action Surface
 
-</details>
+The extension's canonical tool registry covers navigation, search, clicking, typing, keyboard events, scrolling, waiting, tabs, spreadsheets, coordinate interactions, DOM mutation helpers, read-only inspection, site guide lookup, memory search, and task finalization signals.
 
-### Task Flow
+The MCP server exposes a curated public surface around that registry:
 
-1. **Input**: User describes a task in natural language
-2. **Analysis**: FSB reads the current page (DOM elements, forms, navigation)
-3. **Memory Retrieval**: Relevant memories (site knowledge, past workflows, selectors) load for context
-4. **Planning**: AI generates a step by step action plan from page context, site guides, and memories
-5. **Execution**: Actions run with smart delays, visual feedback, and error handling
-6. **Verification**: Post action state validation confirms the intended effect
-7. **Iteration**: Repeats until task completion, stuck detection triggers recovery, or timeout
-8. **Memory Extraction**: Episodic, semantic, and procedural memories are extracted and AI enriched
-9. **Feedback**: User receives real time updates and final results in the chat
+| Surface | Count | Examples |
+|---------|-------|----------|
+| Visual sessions | 2 | `start_visual_session`, `end_visual_session` |
+| Autopilot | 3 | `run_task`, `stop_task`, `get_task_status` |
+| Manual control | 37 | `execute_js`, `navigate`, `click`, `type_text`, `drag`, `set_attribute` |
+| Read-only inspection | 8 | `read_page`, `get_dom_snapshot`, `get_site_guide`, `read_sheet` |
+| Observability | 5 | `list_sessions`, `get_logs`, `search_memory` |
+| Vault | 4 | `list_credentials`, `fill_credential`, `use_payment_method` |
 
-### Automation Lifecycle
-
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant UI as Chat UI
-    participant BG as Background Worker
-    participant AI as AI Provider
-    participant CS as Content Scripts
-    participant WP as Web Page
-    participant MEM as Memory System
-
-    U->>UI: Describe task in natural language
-    UI->>BG: Send task request
-    BG->>MEM: Retrieve relevant memories
-    MEM-->>BG: Site knowledge, past workflows, selectors
-
-    loop Until task complete or timeout
-        BG->>CS: Request DOM snapshot
-        CS->>WP: Analyze page structure
-        WP-->>CS: DOM elements, forms, navigation
-        CS-->>BG: Structured page data
-
-        BG->>AI: Send context + task + memories
-        AI-->>BG: Action plan (tool calls)
-
-        BG->>CS: Execute actions
-        CS->>WP: Click, type, scroll, navigate
-        WP-->>CS: Action result
-
-        CS->>CS: Verify action succeeded
-        CS-->>BG: Verification result
-        BG->>UI: Progress update
-    end
-
-    BG->>MEM: Extract and store new memories
-    BG->>UI: Final results
-    UI->>U: Display completion summary
-```
+Read-only tools bypass the mutation queue where safe. Mutation tools are serialized so two clients do not click, type, or navigate at the same time.
 
 ---
 
-## Configuration
+## AI Providers
 
-### Basic Setup
+FSB uses one universal provider path for hosted, routed, local, and custom OpenAI-compatible models.
 
-Open settings through the extension popup or options page:
+| Provider | Default or fallback model | Notes |
+|----------|---------------------------|-------|
+| xAI | `grok-4-1-fast` | Default provider, fast automation profile. |
+| Google Gemini | `gemini-2.5-flash` | Includes free/low cost model options depending on Google availability. |
+| OpenAI | `gpt-4o` | Strong general automation and structured output. |
+| Anthropic | `claude-sonnet-4-6` | Strong reasoning and form-heavy workflows. |
+| OpenRouter | `openai/gpt-4o` | Single key for routed models; live discovery supported. |
+| LM Studio | Live local model list | No API key; reads `/v1/models` from a local LM Studio server. |
+| Custom | User supplied model | Any compatible chat completions endpoint. |
 
-- **AI Provider and Model**: Pick provider and model (see table below)
-- **API Keys**: Configure keys for your provider(s)
-- **Action Delay**: Customize timing between actions (500 to 5000 ms)
-- **Max Iterations**: Set automation loop limits (5 to 50)
-- **Debug Mode**: Enable detailed logging
-- **DOM Optimization**: Configure element limits and viewport prioritization
+The extension includes 30 fallback model entries and live model discovery for supported hosted providers. Pricing and model availability change frequently, so use the provider dashboard as the source of truth for billing.
 
-### Supported Models
+### Provider Configuration Notes
 
-<details>
-<summary><b>View all 21 models with pricing</b></summary>
+- xAI, Gemini, OpenAI, Anthropic, and OpenRouter use API keys saved in Chrome storage.
+- LM Studio requires the local server to be enabled and reachable from Chrome.
+- Custom endpoints should point to a chat completions-compatible URL.
+- The saved model is preserved even when it is not in the bundled fallback list, so newly discovered models are not silently overwritten after a service worker restart.
+- If discovery fails, the options page falls back to bundled models and shows the discovery status inline.
 
-#### xAI Grok
-| Model | Description | Cost (per 1M tokens) |
-|-------|-------------|---------------------|
-| **grok-4-1-fast** | High speed with reasoning, 2M context (Recommended) | $0.20 / $0.50 |
-| grok-4-1-fast-non-reasoning | Faster responses, no reasoning | $0.20 / $0.50 |
-| grok-4 | Complex reasoning model | $3.00 / $15.00 |
-| grok-code-fast-1 | Dedicated code generation and debugging | $0.20 / $1.50 |
-| grok-3 | Legacy flagship model | $5.00 / $25.00 |
-| grok-3-mini | Budget option with reasoning | $0.30 / $1.50 |
+Provider-specific prompt formatting lives in the AI layer, but the execution loop is intentionally shared. That keeps action planning, tool validation, transcript storage, cost tracking, and error handling consistent across models.
 
-#### OpenAI GPT
-| Model | Description | Cost (per 1M tokens) |
-|-------|-------------|---------------------|
-| **gpt-4o** | Most capable multimodal model | $5.00 / $20.00 |
-| chatgpt-4o-latest | Always newest GPT-4o version | $5.00 / $20.00 |
-| gpt-4o-mini | Affordable and fast | $0.15 / $0.60 |
-| gpt-4-turbo | Previous generation flagship | $10.00 / $30.00 |
+### Model Discovery And Fallbacks
 
-#### Anthropic Claude
-| Model | Description | Cost (per 1M tokens) |
-|-------|-------------|---------------------|
-| **claude-sonnet-4-5** | Latest flagship with 200K context | $3.00 / $15.00 |
-| claude-haiku-4-5 | Fast and cost effective, 200K context | $1.00 / $5.00 |
-| claude-opus-4-1 | Most powerful reasoning model | $15.00 / $75.00 |
-| claude-sonnet-4 | Previous Sonnet | $3.00 / $15.00 |
-| claude-opus-4 | Previous Opus | $15.00 / $75.00 |
-| claude-sonnet-3.7 | Extended thinking variant | $3.00 / $15.00 |
+Model discovery queries provider model endpoints where available, filters non-text models, normalizes the list, and caches successful results. If a provider is offline, the key is missing, or discovery fails, FSB keeps the UI usable with bundled fallback models.
 
-#### Google Gemini
-| Model | Description | Cost (per 1M tokens) |
-|-------|-------------|---------------------|
-| **gemini-2.5-flash** | Latest with thinking capabilities | $0.30 / $2.50 |
-| gemini-2.5-flash-lite | Budget option with 1M context | $0.10 / $0.40 |
-| gemini-2.5-pro | Most powerful with 2M context | $1.25 / $10.00 |
-| gemini-2.0-flash | Fast and efficient (FREE) | $0.00 / $0.00 |
-| gemini-2.0-flash-exp | Free experimental | $0.00 / $0.00 |
+The fallback table currently includes:
 
-</details>
+- 6 xAI models
+- 5 Gemini models
+- 4 OpenAI models
+- 9 Anthropic models
+- 6 OpenRouter presets
+- live-only LM Studio models
 
-#### Cost Tiers
+Custom providers are intentionally open-ended. The model name and endpoint come from user settings, and the universal provider handles OpenAI-compatible request/response behavior.
 
-- **Free**: Gemini 2.0 Flash (experimental)
-- **Budget**: grok-4-1-fast ($0.20/$0.50) or GPT-4o Mini ($0.15/$0.60)
-- **Balanced**: Gemini 2.5 Flash ($0.30/$2.50) or Claude Haiku 4.5 ($1.00/$5.00)
-- **Performance**: GPT-4o ($5.00/$20.00) or Claude Sonnet 4.5 ($3.00/$15.00)
-- **Maximum**: Claude Opus 4.1 ($15.00/$75.00) or Gemini 2.5 Pro ($1.25/$10.00)
+---
 
-### Advanced Configuration
+## Site Intelligence And Memory
 
-#### Extension Options Page
-1. **Right click the extension icon**, then select "Options"
-2. **Or visit**: `chrome-extension://[extension-id]/options.html`
+FSB ships site guides for 17 categories, including ecommerce, finance, social, travel, coding, email, career, gaming, productivity, media, design, news, utilities, sports, reference, music, and games. Guides provide selectors, navigation patterns, workflow hints, and known site quirks.
 
-#### Security Features
-- **Encrypted Storage**: API keys are AES-GCM encrypted in Chrome storage
-- **Secure Configuration**: No plain text files or environment variables
-- **Session Management**: Automatic cleanup and secure key handling
-- **XSS Protection**: DOMPurify sanitization for all rendered chat content
-- **Tab Security**: Automation is restricted to the active session tab
+Long term memory records:
+
+- **Episodic**: what happened in a specific session.
+- **Semantic**: facts learned about a domain or UI.
+- **Procedural**: repeatable workflows and selectors that worked.
+
+Memory operations are tracked separately from normal automation costs. The options dashboard exposes usage charts, memory detail panels, logs, and export controls.
+
+### Guide Categories
+
+| Category | Examples |
+|----------|----------|
+| Ecommerce | Amazon, eBay, Walmart, Best Buy, Target |
+| Finance | Yahoo Finance, TradingView, Google Finance, Coinbase |
+| Social | YouTube, Reddit, LinkedIn, Instagram, TikTok |
+| Travel | Booking, Kayak, Google Travel, Airbnb, airlines |
+| Coding | GitHub, Stack Overflow, LeetCode, Codeforces |
+| Email and productivity | Gmail, Outlook, Google Workspace, Notion, Jira, Trello |
+| Career | Workday, Greenhouse, Lever, major employer job portals |
+| Media and design | Video players, voice recorders, Photopea, Miro, Excalidraw |
+| Edge cases | CAPTCHA-like sliders, file upload, cookie opt-out, buried login links |
+
+Site guides are helpers, not hard-coded scripts. FSB still reads the current DOM each turn and uses guides as context for better selectors and fewer repeated mistakes.
+
+### Memory Lifecycle
+
+After a task, FSB can extract memories from the session transcript and action history. Memories are scored, tagged, consolidated, and later retrieved by domain, task type, recency, and keyword relevance. This lets FSB reuse what it learned without stuffing every previous session into every prompt.
+
+Memory and site maps are especially useful for:
+
+- repeated workflows on the same domain
+- pages with custom controls or unstable selectors
+- identifying successful login, search, checkout, or form-fill patterns
+- avoiding known bad selectors or repeated failed actions
+- visualizing learned site structure from the options dashboard
+
+---
+
+## Security And Safety
+
+- API keys are encrypted with AES-GCM and stored in Chrome storage.
+- Credential and payment vault flows avoid sending raw secrets over the MCP bridge.
+- Rendered chat output is sanitized with DOMPurify.
+- Automation is scoped to the active session tab where possible.
+- Logs can be reviewed or disabled for sensitive use cases.
+
+Use separate API keys for development and production, rotate keys regularly, respect website terms of service, and supervise automation on anything account, finance, shopping, or data-entry related.
+
+### Current Boundaries
+
+- FSB does not bypass browser restrictions on internal pages.
+- CAPTCHA solving support is a framework and optional service integration, not a guarantee.
+- The extension can interact with the active page, tabs, and debugger-backed coordinate tools because those permissions are declared in the MV3 manifest.
+- Saved credentials and payment methods require explicit user configuration and unlock flows.
+- Automation should be treated like a fast assistant operating your browser, not like an unattended production worker.
+
+### Data Handling
+
+Provider calls receive the page/task context needed to complete the requested automation. That can include visible page text, form labels, selectors, and user-supplied task instructions. Avoid running automation on sensitive pages unless you are comfortable sending that task context to the selected model provider.
+
+FSB does not require a hosted FSB account for local extension use. The showcase backend and dashboard pairing server are separate from normal local extension operation.
 
 ---
 
 ## Development
 
-### Project Structure
-
-<details>
-<summary><b>View full project structure</b></summary>
-
-```
-FSB/
-  agents/                       # Background automation agents
-    agent-executor.js
-    agent-manager.js
-    agent-scheduler.js
-    server-sync.js
-  ai/                           # AI integration layer
-    ai-integration.js
-    ai-providers.js
-    universal-provider.js
-  assets/                       # Icons and images
-  config/                       # Configuration management
-    config.js
-    init-config.js
-    secure-config.js
-  content/                      # Content script modules (10 files)
-    accessibility.js
-    actions.js
-    dom-analysis.js
-    dom-state.js
-    init.js
-    lifecycle.js
-    messaging.js
-    selectors.js
-    utils.js
-    visual-feedback.js
-  lib/                          # Libraries and subsystems
-    memory/                     # Long term memory (9 modules)
-      cross-site-patterns.js
-      memory-consolidator.js
-      memory-extractor.js
-      memory-manager.js
-      memory-retriever.js
-      memory-schemas.js
-      memory-storage.js
-      sitemap-converter.js
-      sitemap-refiner.js
-    visualization/
-      site-graph.js
-      knowledge-graph.js
-      d3-*.min.js
-    chart.min.js
-    marked.min.js
-    mermaid.min.js
-    purify.min.js
-  Logs/                         # Session logs (runtime)
-  mcp/                          # MCP server package (62 tools)
-  showcase/server/              # Optional Node.js backend (deploy target)
-  server-py/                    # Optional Python/Flask backend
-  showcase/                     # Marketing website (Angular)
-  site-guides/                  # Domain specific AI guides (9 categories)
-  site-maps/                    # Generated site structure maps
-  ui/                           # popup, sidepanel, options, unlock
-  utils/                        # action-verification, analytics, logger, etc.
-  background.js                 # Service worker
-  manifest.json                 # Manifest V3
-  package.json                  # Project metadata
-```
-
-</details>
-
-### Building and Testing
+Install root dependencies when running validation or tests:
 
 ```bash
-git clone https://github.com/lakshmanturlapati/FSB.git
-cd FSB
-# Open chrome://extensions/ in developer mode
-# Click "Load unpacked" and select the FSB directory
+npm install
+npm --prefix mcp install
+npm --prefix showcase/angular install
 ```
 
-No build step or npm install is required. FSB runs directly as a Chrome extension.
+Common checks:
 
-### Debugging
+```bash
+npm run validate:extension
+npm test
+npm run test:mcp-smoke
+npm --prefix showcase/angular run build
+```
 
-- Enable **Debug Mode** in the options page for detailed logging
-- Inspect the **background script console** via `chrome://extensions/` (click "Inspect views: service worker")
-- Use the **log viewer** in the options page to review session history
-- Check the **browser console** on any page for content script logs
+The CI workflow runs these checks in separate jobs:
 
-### Contributing Guidelines
+- extension validation and Node tests
+- MCP TypeScript build and smoke tests
+- Angular showcase build
 
-1. **Fork the repository** and create a feature branch
-2. **Follow the existing code style** and patterns
-3. **Test thoroughly** across different websites
-4. **Update documentation** for any API changes
-5. **Submit a pull request** with a clear description
+Other useful commands:
 
----
+```bash
+npm run showcase:serve
+npm run showcase:smoke
+npm --prefix mcp run build
+npm --prefix mcp run dev
+```
 
-## Multi Model AI Integration
+Debugging:
 
-<div align="center">
+- Inspect the service worker from `chrome://extensions/`.
+- Check the browser console on the active tab for content script logs.
+- Use the options page log viewer for session and action history.
+- For MCP issues, run `npm run test:mcp-smoke`, then `fsb-mcp-server doctor`, then `fsb-mcp-server status --watch`.
 
-![xAI Grok](https://img.shields.io/badge/xAI_Grok-6_Models-000000?style=for-the-badge&logo=x&logoColor=white)
-![OpenAI GPT](https://img.shields.io/badge/OpenAI_GPT-4_Models-412991?style=for-the-badge&logo=openai&logoColor=white)
-![Anthropic Claude](https://img.shields.io/badge/Anthropic_Claude-6_Models-D4A574?style=for-the-badge&logo=anthropic&logoColor=white)
-![Google Gemini](https://img.shields.io/badge/Google_Gemini-5_Models-4285F4?style=for-the-badge&logo=googlegemini&logoColor=white)
+### Change Guidelines
 
-</div>
+- Keep behavior-specific docs close to the package that owns the behavior.
+- Update the root README only for public setup, architecture, or feature changes.
+- Update `mcp/README.md` when tool names, counts, transports, diagnostics, or installer platforms change.
+- Update `extension/README.md` when manifest entry points, extension loading, packaging, or validation changes.
+- Update `showcase/README.md` when Angular, deploy, crawler, or site build behavior changes.
+- Prefer tests for any shared contract between the extension and MCP server; stale docs are usually symptoms of missing contract checks.
 
-FSB supports four AI providers through a universal, model agnostic architecture. Each has unique strengths.
+### Release Sanity Checks
 
-### Supported AI Providers
+Before cutting a release, verify:
 
-#### xAI Grok
-- **Strengths**: Fast responses, creative problem solving, handles complex web interactions
-- **Best for**: Dynamic websites, real time automation, unconventional UI patterns
-- **Recommended**: `grok-4-1-fast` (2M context, high speed, low cost)
+- root `package.json` version matches `extension/manifest.json`
+- `mcp/package.json` matches `mcp/src/version.ts`
+- README version badges and "what's new" sections match package metadata
+- screenshots and logos resolve from tracked paths
+- MCP README tool counts match the registered runtime surface
+- showcase README matches Angular major version and build output path
+- no retired background-agent behavior is advertised as active functionality
 
-#### OpenAI GPT
-- **Strengths**: Broad knowledge, reliable structured output, strong reasoning
-- **Best for**: General purpose automation, data extraction, multi step workflows
-- **Recommended**: `gpt-4o` (multimodal, consistent results)
+### Documentation Ownership
 
-#### Anthropic Claude
-- **Strengths**: Advanced reasoning, strong code understanding, careful and thorough
-- **Best for**: Complex forms, code heavy sites, nuanced tasks
-- **Recommended**: `claude-sonnet-4-5` (balanced performance and cost)
-
-#### Google Gemini
-- **Strengths**: Reliable structured output, analytical, FREE tier available
-- **Best for**: Structured forms, data entry, systematic workflows, budget usage
-- **Recommended**: `gemini-2.5-flash` (latest with thinking)
-
-### Universal Provider Architecture
-
-FSB's universal provider eliminates provider specific code:
-
-- **Any OpenAI compatible API**: Works with any endpoint that follows the OpenAI chat completions format
-- **Automatic parameter discovery**: Learns supported parameters by retrying on errors
-- **Self healing**: Adapts when APIs change or add/remove parameters
-- **Configuration caching**: Remembers successful configurations per model
-- **Custom endpoints**: Add new providers by configuring an endpoint URL, no code changes
-
-### Advanced Prompt Engineering
-
-- **Task type detection**: Classifies tasks (search, form, extraction, navigation) for optimized prompts
-- **Context aware system prompts**: Dynamic tool documentation based on task type
-- **Model specific formatting**: Tailored instructions for each provider
-- **Enter first strategy**: Natural form filling patterns
-- **Retry with enhancement**: Progressive prompt improvement on parsing failures (3 attempts with backoff)
-
-### Comprehensive Action Library
-
-<details>
-<summary><b>View all 47 browser actions by category</b></summary>
-
-**Navigation**: `navigate`, `searchGoogle`, `refresh`, `goBack`, `goForward`
-
-**Clicking**: `click`, `clickSearchResult`, `rightClick`, `doubleClick`, `hover`, `focus`, `blur`
-
-**Text Input**: `type`, `clearInput`, `selectText`, `pressEnter`, `keyPress`, `pressKeySequence`, `typeWithKeys`, `sendSpecialKey`
-
-**Form Controls**: `selectOption`, `toggleCheckbox`
-
-**Information**: `getText`, `getAttribute`, `setAttribute`, `getEditorContent` (Monaco, CodeMirror, etc.)
-
-**Scrolling**: `scroll`, `scrollToTop`, `scrollToBottom`, `scrollToElement`
-
-**Multi Tab**: `openNewTab`, `switchToTab`, `closeTab`, `listTabs`, `getCurrentTab`, `waitForTabLoad`
-
-**Waiting and Detection**: `waitForElement`, `waitForDOMStable`, `detectLoadingState`
-
-**Game and Arrow Controls**: `gameControl`, `arrowUp`, `arrowDown`, `arrowLeft`, `arrowRight`
-
-**Special**: `solveCaptcha`, `moveMouse`, `verifyMessageSent`
-
-</details>
-
----
-
-## Site Specific Intelligence
-
-FSB ships a site guides system that gives the AI domain specific knowledge, improving accuracy and reducing token usage.
-
-### How It Works
-
-When you navigate to a supported domain, FSB loads the relevant guide. Each guide provides:
-
-- **Domain specific selectors**: Pre mapped CSS selectors for common elements
-- **Workflow patterns**: Step by step instructions for common tasks
-- **Navigation hints**: How the site's UI is structured
-- **Gotchas and workarounds**: Known quirks and how to handle them
-
-### Supported Domains
-
-| Category | Sites |
-|----------|-------|
-| **Ecommerce** | Amazon, eBay, Walmart, similar shopping sites |
-| **Finance** | Yahoo Finance, TradingView, financial platforms |
-| **Social Media** | Major social media platforms |
-| **Travel** | Flight booking and hotel reservation sites |
-| **Coding** | GitHub, LeetCode, developer platforms |
-| **Email** | Gmail, Outlook, email services |
-| **Career** | LinkedIn, Indeed, job platforms |
-| **Gaming** | Steam, Epic, gaming platforms |
-| **Productivity** | Google Workspace, Notion, productivity tools |
-
-Site guides cut token usage by 30 to 40% by giving focused context instead of forcing the AI to analyze the full DOM.
-
----
-
-## Long Term Memory System
-
-FSB maintains a persistent memory system that learns from sessions and improves over time.
-
-### Memory Types
-
-- **Episodic Memory**: Records of specific sessions, what happened, what actions were taken, what succeeded or failed. Used to avoid repeating mistakes and replay successful workflows.
-- **Semantic Memory**: Factual knowledge about websites, structure, navigation, important selectors, form layouts. Built up across visits to the same domain.
-- **Procedural Memory**: Verified step by step workflows for login sequences, checkout flows, and data entry. Includes success rate tracking per procedure.
-
-### How It Works
-
-1. **Extraction**: After each session, the memory extractor analyzes the log and identifies memories worth keeping
-2. **AI Enrichment**: Each memory passes through AI analysis for categorization, tagging, and quality scoring
-3. **Consolidation**: The consolidator periodically merges related memories, deduplicates entries, and prunes low quality data
-4. **Retrieval**: When a new task starts, the retriever loads relevant memories based on domain, task type, and context
-5. **Cross Site Patterns**: Detects recurring UI patterns (login forms, navigation menus, modal dialogs) across websites and creates generalized knowledge
-
-### Site Visualization
-
-- **Per Site Graphs**: D3.js force directed mind maps for individual site memories
-- **Knowledge Graph**: Consolidated 3D Canvas view rendering all 9 site guide categories and 43+ supported sites as a single rotating graph, with search highlighting and detail level toggles
-
-### Cost Tracking
-
-Memory operations that use AI (extraction, enrichment, cross site analysis) are tracked separately from automation costs. The Memory section in the options dashboard shows a dedicated cost panel.
-
----
-
-## Background Agents
-
-FSB supports scheduled background automation through its agent system.
-
-### How Agents Work
-
-- **Creation**: Define a task, target URL, and schedule from the options dashboard
-- **Scheduling**: chrome.alarms run at specified intervals (hourly, daily, weekly, custom)
-- **Execution**: When triggered, the executor opens the target page, runs the task, and captures results
-- **Run History**: Every run is logged with timestamps, outcomes, and session details
-- **Session Replay**: Past runs can be reviewed step by step
-
-### Server Backends (Optional)
-
-For persistent agent data beyond Chrome storage limits:
-
-- **Node.js** (`showcase/server/`): Express based API server
-- **Python/Flask** (`server-py/`): Alternative backend with SQLite and Fly.io deployment
-
-Server backends are optional. Agents work fully with local Chrome storage.
-
----
-
-## Visual Feedback System
-
-FSB provides real time visual indicators during automation:
-
-- **Viewport Glow**: Colored border indicating state. Thinking (blue pulse), acting (amber), complete (green flash), error (red)
-- **Element Highlights**: Target element gets an animated glow before the action runs
-- **Progress Overlay**: Step counter and progress bar showing current action and overall progress
-
----
-
-## Analytics and Monitoring
-
-### Usage Tracking
-- **Token consumption** with per model cost calculation
-- **Dual cost tracking**: Automation and memory operations tracked separately
-- **Success/failure rates** for task and action categories
-- **Performance metrics** including execution time and AI response latency
-- **Error analysis** for debugging
-- **30 day data retention** with automatic cleanup
-
-### Dashboard Features
-- Real time automation status
-- Historical usage charts with cost breakdown by model and time period
-- Overall cost summary panel in the Dashboard hero
-- Dedicated memory operations cost panel in the Memory section
-- Memory tab with auto refresh, detail panels, and inline controls
-- Session history viewer with detailed action logs
-- Settings export for backup and migration
-- Detailed logs with filtering options
-
----
-
-## Security and Privacy
-
-### Data Handling
-- **No personal data** is sent externally except as required for task execution
-- **API keys** are AES-GCM encrypted in local storage
-- **Session data** is cleared after completion
-- **Optional logging** can be disabled for sensitive operations
-- **XSS protection** via DOMPurify on all rendered chat content
-
-### Best Practices
-- Use separate API keys for development and production
-- Enable encrypted storage for production
-- Rotate API keys regularly
-- Review logs for any unintended actions
-- Test on non sensitive websites first
-
-### Safety Guidelines
-- **Always monitor automation** via visual feedback
-- **Start with safe sites** like test pages or your own domains
-- **Verify results** and double check outcomes
-- **Tab isolation**: FSB controls only the active session tab
-- **Report issues** to help improve FSB
-- **Use responsibly**: Respect website terms of service and rate limits
-
----
-
-## Roadmap
-
-### Completed in v0.9.50
-- Full automation engine with smart iteration and stuck recovery
-- Four AI providers (xAI, OpenAI, Anthropic, Gemini) across 21 models
-- Universal model agnostic provider architecture
-- Modern chat UI with markdown, mermaid, and Chart.js
-- Site specific intelligence across 9 domain categories
-- Action verification and visual feedback
-- Analytics dashboard with cost tracking
-- Encrypted configuration and secure API key storage
-- Multi tab automation
-- Comprehensive logging and debugging tools
-
-### Completed in v9.1 to v9.3
-- Long term memory (episodic, semantic, procedural)
-- AI enriched memory extraction
-- Cross site pattern analysis
-- D3.js site visualization
-- Background agent system with scheduling and run history
-- Content script modularization (10 focused modules)
-- Memory intelligence overhaul with detail viewers and cost tracking
-- Optional server backends (Node.js and Python/Flask)
-- Sitemap generation and refinement
-- Site guides viewer with consolidated 3D knowledge graph
-
-### Completed in v0.9.34 to v0.9.36
-- Vault management with numeric PIN unlock, credential CRUD, payment method storage
-- MCP server v0.7.3 with bridge lifecycle reconnect across service worker wakes
-- Centralized MCP tool routing contract
-- Layered MCP diagnostics (`doctor`, `status --watch`)
-- Explicit visual session lifecycle for MCP clients
-- Trusted client badges (Claude, Codex, Cursor, etc.) on the automation overlay
-- Visual session persistence across content script reinjection
-- One command install for 10+ MCP platforms
-- Secure vault bridge handlers with sensitive content redaction
-- Payment confirmation timeout alignment across MCP boundary
-
-### Future
-- Advanced CAPTCHA solver integration (Buster, CapSolver, 2Captcha)
-- Workflow templates and task saving
-- Chrome Web Store publication
-- Visual element recognition and computer vision
-- Plugin architecture for custom actions
-- Enterprise features, team collaboration, and compliance
-
----
-
-## Acknowledgments
-
-FSB is inspired by **Project Mariner** from Google DeepMind, designed as an open source alternative accessible to everyone. The multi model approach is made possible by:
-
-**AI Model Providers**
-- **xAI Team**: For powerful and accessible Grok models
-- **OpenAI**: For the GPT family and the chat completions API standard
-- **Anthropic**: For Claude models with advanced reasoning
-- **Google AI**: For Gemini, including a free tier
-
-**Community and Inspiration**
-- **Project Mariner**: For demonstrating the potential of AI powered browsing
-- **Chrome Extensions Community**: For excellent documentation and resources
-- **Open Source Contributors**: Every bug report, feature request, and pull request
-- **Beta Testers**: Community members helping test across different sites
-
-Every contributor, tester, and community member helps push FSB forward.
+The root README should describe what a new user needs to understand before installing, testing, or choosing an integration path. Detailed package behavior belongs in the package README that owns it. This split keeps the public overview useful while still giving maintainers a clear place to update tool surfaces, extension entry points, or showcase deploy instructions.
 
 ---
 
 ## License
 
-This project is licensed under the Business Source License 1.1. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the Business Source License 1.1. See [LICENSE](LICENSE).
 
----
+## Support And Contributing
 
-## Contributing
-
-**FSB thrives on community contributions.** Bug fixes, features, documentation, testing on new websites, or feedback: every contribution counts.
-
-### Priority Contribution Areas
-
-- **Testing and Feedback**: Try FSB on different websites and report what works
-- **Bug Reports**: Document issues with steps to reproduce
-- **Feature Requests**: Share ideas for better automation
-- **Code Contributions**: Implement features, fix bugs, optimize performance
-- **Documentation**: Improve guides, add examples, create tutorials
-- **AI Model Integration**: Add support for new models and providers
-- **Site Guides**: Add domain specific guides for new websites
-
-### Getting Started
-
-1. **Start Testing**: Download FSB and try it on your favorite websites
-2. **Report Your Experience**: Use the [issues page](https://github.com/lakshmanturlapati/FSB/issues)
-3. **Join Discussions**: Engage with the community in GitHub discussions
-4. **Pick an Issue**: Look for "good first issue" labels
-5. **Submit Code**: Fork, improve, and submit pull requests
-
-Contributors are recognized in the acknowledgments and become part of FSB's story.
-
----
-
-## Support
-
-- **GitHub Issues**: [Report bugs or request features](https://github.com/lakshmanturlapati/FSB/issues)
-- **Options Page**: Built in help section and log viewer
-- **Community**: GitHub discussions in this repository
-
----
+- Report bugs and feature requests in [GitHub Issues](https://github.com/lakshmanturlapati/FSB/issues).
+- Include the task prompt, target site, provider/model, logs, and reproduction steps where possible.
+- Pull requests should update tests and docs when behavior, setup, or public interfaces change.
 
 <div align="center">
 
-**Made with care by [Lakshman Turlapati](https://github.com/lakshmanturlapati)**
-
-**Star this repository if FSB helps you automate your browsing.**
+**Made by [Lakshman Turlapati](https://github.com/lakshmanturlapati)**
 
 *FSB Full Self Browsing: AI powered automation, accessible to everyone.*
-
-[Back to top](#fsb-v0936-full-self-browsing)
 
 </div>

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,63 +1,72 @@
 # FSB Chrome Extension
 
-The `extension/` directory contains the entire Chrome extension package
-(Manifest V3). Load this directory as an unpacked extension in Chrome to
-run FSB locally.
+`extension/` is the unpacked Chrome extension package for FSB v0.9.50. Load this directory, not the repository root, when running locally.
 
-## Load as Unpacked
+## Load Unpacked
 
-1. Open `chrome://extensions` in Chrome (or any Chromium-based browser
-   version 88+).
-2. Toggle **Developer mode** on (top-right).
-3. Click **Load unpacked** and select the `extension/` directory at the
-   root of this repository (i.e., the directory containing this README).
-4. The "FSB" extension appears in your extensions list. Pin it from the
-   toolbar puzzle icon for easy access.
-5. Click the FSB toolbar icon to open the popup, or right-click and
-   choose **Open side panel** for the persistent panel.
+1. Open `chrome://extensions` in Chrome or another Chromium browser.
+2. Enable **Developer mode**.
+3. Click **Load unpacked**.
+4. Select the repository's `extension/` directory.
+5. Pin FSB from the toolbar puzzle icon.
+6. Open the popup from the toolbar, or right-click the extension and choose **Open side panel**.
 
-To pick up code changes during development, click the **reload** icon
-on the FSB card in `chrome://extensions`. Reload the open tabs after
-reloading the extension so the content scripts re-inject.
+After code changes, reload the extension from `chrome://extensions` and refresh any open tabs so content scripts re-inject.
 
 ## Key Entry Points
 
 | Path | Role |
 |------|------|
-| `manifest.json` | MV3 manifest (permissions, entry points, web-accessible resources) |
-| `background.js` | Service worker; orchestrates AI calls, tool execution, sessions |
-| `canvas-interceptor.js` | MAIN-world content script; runs at `document_start` |
-| `content/` | Content scripts (DOM analysis, action execution, lifecycle, messaging) |
-| `ui/` | Popup, side panel, control panel, options HTML/CSS/JS |
-| `ai/` | AI provider integrations, tool definitions, agent loop, transcript store |
-| `agents/` | Agent runtime (executor, manager, scheduler, server-sync) |
-| `ws/` | WebSocket clients (MCP bridge, MCP tool dispatcher, ws-client) |
-| `offscreen/` | Offscreen document (speech-to-text) |
-| `utils/` | Shared utilities (analytics, logger, ring buffer, redaction, etc.) |
-| `lib/` | Vendored third-party libraries (Chart.js, gpt-tokenizer, mermaid, etc.) |
-| `site-guides/` | Per-site automation guides |
-| `site-maps/` | Generated site-map JSON (web-accessible) |
-| `test-data/` | Fixture data exposed to content scripts (web-accessible) |
-| `shared/` | UI styles shared across surfaces |
-| `config/` | Extension config bootstrap (config.js, init-config.js, secure-config.js) |
-| `assets/` | Icons and image assets |
+| `manifest.json` | MV3 manifest, permissions, entry points, and web-accessible resources. |
+| `background.js` | Service worker for sessions, model calls, MCP bridge handling, storage, and orchestration. |
+| `canvas-interceptor.js` | MAIN-world content script loaded at `document_start`. |
+| `content/` | DOM analysis, action execution, messaging, lifecycle, visual feedback, and DOM streaming. |
+| `ui/` | Popup, side panel, control panel, unlock screens, and shared UI behavior. |
+| `ai/` | Provider integration, model discovery, tool registry, agent loop, transcripts, and state emitters. |
+| `ws/` | WebSocket bridge client and MCP tool dispatcher. |
+| `lib/` | Vendored libraries plus memory and visualization subsystems. |
+| `site-guides/` | Domain and category-specific automation guidance. |
+| `config/` | Defaults, migration, and secure encrypted configuration. |
+| `assets/` | Icons, logos, and screenshots. |
 
-## Packaging for the Chrome Web Store
+## Validation
 
-The repo-root `package.json` defines `npm run package`, which produces a
-zip archive of the extension. Run from the repository root, not from
-`extension/`. The zip excludes development files and node_modules.
+Run from the repository root:
 
-## CI Validation
+```bash
+npm run validate:extension
+npm test
+```
 
-From the repository root: `npm run validate:extension` performs static
-validation (manifest sanity, JS syntax check across all extension JS
-files). The Node test suite (`npm test`) covers extension modules that
-can run under Node (analytics, cost tracker, transcript store, MCP
-bridge contracts, etc.).
+`validate:extension` checks manifest sanity and JavaScript syntax across the extension tree. The Node test suite covers extension modules that can run outside Chrome, including analytics, costs, transcript storage, tool routing, MCP bridge contracts, and regression cases.
 
-## Repository Layout
+## Debugging
 
-See the root `README.md` for the full repository overview, including
-the MCP server (`mcp/`) and the showcase site
-(`showcase/`).
+- Inspect the service worker from `chrome://extensions` with **Inspect views: service worker**.
+- Check the active tab console for content script logs.
+- Use the options page log viewer for session history, action results, and warnings.
+- If MCP calls fail, confirm the MCP bridge is connected and the active tab is not a restricted browser page.
+
+## Manifest Notes
+
+The extension declares permissions for tabs, scripting, storage, side panel, debugger-backed coordinate tools, web navigation, alarms, clipboard write, offscreen speech-to-text, and broad host access. Those permissions support supervised browser automation and should be reviewed when adding new public behavior.
+
+## Local Data
+
+The extension stores settings, encrypted keys, analytics, memory, logs, vault data, and legacy agent records in Chrome storage. Uninstalling the extension or clearing extension storage can remove that local state. Export settings from the control panel before destructive browser cleanup if you need to preserve local configuration.
+
+## Public Surfaces
+
+The extension is driven through:
+
+- popup and side panel chat
+- control panel settings and diagnostics
+- content-script visual overlay
+- local WebSocket bridge for `fsb-mcp-server`
+- optional showcase/dashboard sync flows
+
+## Packaging Note
+
+The root `npm run package` command currently creates a repository-level zip named for the release version. Review the archive contents before using it as a Chrome Web Store submission package.
+
+See the root [README.md](../README.md) for full repo setup, MCP usage, and showcase deployment context.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -3,9 +3,9 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/assets/fsb_logo_dark.png" />
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/assets/fsb_logo_light.png" />
-  <img src="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/assets/fsb_logo_light.png" alt="FSB: Full Self Browsing" width="200" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/extension/assets/fsb_logo_dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/extension/assets/fsb_logo_light.png" />
+  <img src="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/extension/assets/fsb_logo_light.png" alt="FSB: Full Self Browsing" width="200" />
 </picture>
 
 ![FSB](https://img.shields.io/badge/FSB-Full_Self_Browsing-000000?style=for-the-badge)
@@ -13,60 +13,146 @@
 ![MCP](https://img.shields.io/badge/MCP-Server-00B4D8?style=for-the-badge)
 ![License](https://img.shields.io/badge/license-BSL_1.1-F5C518?style=for-the-badge)
 
-[![npm downloads](https://img.shields.io/npm/dm/fsb-mcp-server?style=flat-square&label=Downloads)](https://www.npmjs.com/package/fsb-mcp-server)
-![GitHub Stars](https://img.shields.io/github/stars/LakshmanTurlapati/FSB?style=flat-square&logo=github&label=Stars)
-![Surface](https://img.shields.io/badge/MCP_Surface-Manual%20%7C%20Visual%20%7C%20Autopilot-F97316?style=flat-square)
-![Node](https://img.shields.io/badge/Node-18+-339933?style=flat-square&logo=nodedotjs&logoColor=white)
-
 **Control your browser from any MCP client.**
 
-*Browser automation tools for manual control, client owned visual sessions, autopilot mode, agents, and observability.*
+*Manual browser tools, visual sessions, autopilot, vault, and observability for the FSB Chrome Extension.*
 
-[Quick Start](#quick-start) · [Tools](#tools-62-total) · [Configuration](#configuration) · [FSB Extension](https://github.com/LakshmanTurlapati/FSB)
+[Quick Start](#quick-start) · [Tools](#tools-59-total) · [Diagnostics](#diagnostics) · [Architecture](#architecture)
 
 </div>
 
 ---
 
-## What is this?
+## What It Is
 
-FSB MCP Server connects any MCP capable AI client (Claude Desktop, Claude Code, Cursor, Windsurf, etc.) to the [FSB Chrome Extension](https://github.com/LakshmanTurlapati/FSB) for browser automation. Four operating styles:
+`fsb-mcp-server` connects MCP clients such as Claude Desktop, Claude Code, Codex, Cursor, VS Code, Windsurf, Zed, Cline, Gemini CLI, Continue, and others to the FSB Chrome extension.
 
-- **Manual mode**: fine grained control with click, type, scroll, navigate, read page content
-- **Visual session mode**: show the trusted glow and badge while your MCP client drives the browser step by step
-- **Autopilot mode**: describe a task in natural language and FSB's AI handles every step
-- **Agent mode**: create, run, inspect, and manage scheduled background agents from any MCP client
+The server supports two operating styles:
 
-### What's New in v0.7.3
+- **Manual mode**: the MCP client chooses each step with tools such as `navigate`, `read_page`, `get_dom_snapshot`, `click`, `type_text`, `execute_js`, and `scroll`.
+- **Autopilot mode**: the MCP client calls `run_task`, and FSB's built-in AI loop decides the browser steps.
 
-- **Bridge lifecycle reconnect**: the MCP bridge re arms automatically on service worker wakes, with hub/relay handoff when multiple clients connect
-- **Centralized tool routing**: a route aware dispatcher replaces the old direct dispatch for better reliability and error recovery
-- **Layered diagnostics**: `doctor` and `status --watch` identify the exact failing layer (package, bridge, extension, content script)
-- **Visual session persistence**: sessions survive content script reinjection so the glow stays active across navigations
-- **Trusted client badges**: the automation overlay shows the connected client name (Claude, Codex, Cursor, etc.)
-- **Vault tools**: 4 new tools for secure credential and payment method access without exposing raw secrets
+It also supports visible client-owned visual sessions, vault autofill tools, session logs, memory search, and diagnostic commands.
+
+Use this package when you want your AI client to drive the browser directly while still using FSB's DOM analysis, selector handling, visual overlay, action verification, session logging, memory, and vault boundaries.
+
+### What's New In v0.7.4
+
+- Bridge lifecycle reconnect across service worker wakes.
+- Hub/relay coordination for multiple MCP server instances.
+- Route-aware tool dispatch and centralized parameter mapping.
+- Layered diagnostics through `doctor` and `status --watch`.
+- Persistent visual session glow across content script reinjection.
+- Secure vault tools that avoid sending raw secrets over the bridge.
+- One-command installer coverage for 21 platforms.
+
+Background-agent MCP tools were retired with the extension's background-agent sunset. The `registerAgentTools` shell remains for compatibility, but it registers no live tools.
+
+---
+
+## Supported Clients
+
+The installer knows about 21 platform targets. Some are file-based, some delegate to a native CLI, and some print manual instructions when the host does not expose a safe config file.
+
+Common file or CLI targets:
+
+| Flag | Client |
+|------|--------|
+| `--claude-desktop` | Claude Desktop |
+| `--claude-code` | Claude Code |
+| `--cursor` | Cursor |
+| `--vscode` | VS Code |
+| `--windsurf` | Windsurf |
+| `--cline` | Cline |
+| `--zed` | Zed |
+| `--codex` | Codex CLI / Codex IDE |
+| `--gemini` | Gemini CLI |
+| `--continue` | Continue |
+| `--roo-code` | Roo Code |
+| `--kilo-code` | Kilo Code |
+| `--goose` | Goose |
+| `--amazon-q` | Amazon Q |
+| `--amp` | Amp |
+| `--boltai` | BoltAI |
+| `--opencode` | OpenCode |
+
+Instruction-only or UI-driven targets include JetBrains, ChatGPT, Claude.ai, and Warp. Run `install --list` to see the current registry, config paths, and detection status on your machine.
+
+### Installer Behavior
+
+The installer writes the smallest config entry needed for the selected platform:
+
+```text
+command: npx
+args: -y fsb-mcp-server
+```
+
+For file-based targets, existing config files are parsed, updated, and serialized back in the platform's expected format: JSON, JSONC, TOML, or YAML. For Claude Code, the installer delegates to the `claude mcp add --scope user` CLI command. For instruction-only targets, it prints steps instead of guessing at a private config path.
+
+Use `--dry-run` before `--all` when you want to see planned writes without changing files.
+
+---
 
 ## Prerequisites
 
-- **Node.js 18+**
-- **FSB Chrome Extension** installed and active ([install from GitHub](https://github.com/LakshmanTurlapati/FSB))
+- Node.js 18+
+- FSB Chrome extension installed and active
+- A normal webpage open in Chrome for page-reading and interaction tools
+
+Chrome internal pages such as `chrome://extensions` cannot be controlled by content scripts. Use `list_tabs`, `navigate`, or `open_tab` to move back to a normal page.
+
+---
 
 ## Quick Start
-
-### Transport Overview
 
 FSB uses two local endpoints:
 
 | Endpoint | Purpose |
 |----------|---------|
-| `ws://localhost:7225` | Existing extension bridge. The browser extension connects here. |
-| `http://127.0.0.1:7226/mcp` | Optional local Streamable HTTP MCP endpoint for MCP clients. |
+| `ws://localhost:7225` | Extension bridge. The browser extension connects here. |
+| `http://127.0.0.1:7226/mcp` | Optional Streamable HTTP MCP endpoint for clients that support it. |
 
-The extension pairing contract did **not** change in `0.7.3`. The local HTTP server is only an additional MCP client entrypoint.
+The extension pairing contract did not change in `0.7.4`. Streamable HTTP is an additional client entrypoint; the extension still talks to the local WebSocket bridge.
 
-### Claude Desktop
+### One Command Install
 
-Add to `claude_desktop_config.json`:
+```bash
+npx -y fsb-mcp-server install --claude-desktop
+npx -y fsb-mcp-server install --claude-code
+npx -y fsb-mcp-server install --cursor
+npx -y fsb-mcp-server install --vscode
+npx -y fsb-mcp-server install --windsurf
+npx -y fsb-mcp-server install --codex
+npx -y fsb-mcp-server install --all
+```
+
+Useful installer commands:
+
+```bash
+npx -y fsb-mcp-server install --list
+npx -y fsb-mcp-server install --all --dry-run
+npx -y fsb-mcp-server uninstall --cursor
+```
+
+`install --list` shows all supported platform flags and whether the target config was detected.
+
+### Manual Setup
+
+Claude Code:
+
+```bash
+claude mcp add --scope user fsb -- npx -y fsb-mcp-server
+```
+
+Codex CLI / Codex IDE (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.fsb]
+command = "npx"
+args = ["-y", "fsb-mcp-server"]
+```
+
+Claude Desktop, Cursor (`~/.cursor/mcp.json`), and most JSON-based clients:
 
 ```json
 {
@@ -79,29 +165,7 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
-### Claude Code
-
-```bash
-claude mcp add --scope user fsb -- npx -y fsb-mcp-server
-```
-
-Active right after add. If tools do not appear, run `doctor` and `status --watch` before retrying.
-
-### Codex CLI / Codex IDE
-
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.fsb]
-command = "npx"
-args = ["-y", "fsb-mcp-server"]
-```
-
-Restart Codex or reload the MCP server list after editing `config.toml`.
-
-### VS Code
-
-Add to `mcp.json`:
+VS Code uses the `servers` root key and requires `type: "stdio"`:
 
 ```json
 {
@@ -115,79 +179,9 @@ Add to `mcp.json`:
 }
 ```
 
-Open the MCP view, trust/start the server if prompted, and reload VS Code if it does not start automatically.
-
-### Cursor
-
-Add to `~/.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "fsb": {
-      "command": "npx",
-      "args": ["-y", "fsb-mcp-server"]
-    }
-  }
-}
-```
-
-Restart Cursor after editing `~/.cursor/mcp.json`.
-
-### Windsurf
-
-Supported config paths:
-
-```text
-~/.codeium/windsurf/mcp_config.json
-~/.codeium/mcp_config.json
-```
-
-Use the standard stdio entry:
-
-```json
-{
-  "mcpServers": {
-    "fsb": {
-      "command": "npx",
-      "args": ["-y", "fsb-mcp-server"]
-    }
-  }
-}
-```
-
-Press refresh in Windsurf or reload the client after editing the matching config file.
-
-### OpenCode (manual fallback)
-
-Add to `~/.config/opencode/opencode.json` under the top level `mcp` object:
-
-```json
-{
-  "mcp": {
-    "fsb": {
-      "type": "local",
-      "command": ["npx", "-y", "fsb-mcp-server"]
-    }
-  }
-}
-```
-
-Restart OpenCode after saving the config.
-
-### OpenClaw (manual / unsupported for now)
-
-OpenClaw's MCP config and runtime surface is still unstable, so FSB does **not** claim one command support here yet. Use the stdio command manually only if your OpenClaw build documents a stable MCP format.
-
-```text
-npx -y fsb-mcp-server
-```
-
-Start with `doctor` and `status --watch` before any manual restart or reinstall loop.
+After editing config files, restart or reload the host client if tools do not appear. Claude Code is usually active immediately after `claude mcp add`; Cursor, Claude Desktop, VS Code, and Windsurf often need a restart, refresh, or trust/start action in their MCP UI.
 
 ### Local Streamable HTTP
-
-If your MCP client supports Streamable HTTP, run a local HTTP companion instead of a spawned stdio process:
 
 ```bash
 npx -y fsb-mcp-server serve
@@ -205,359 +199,270 @@ Health check:
 http://127.0.0.1:7226/health
 ```
 
-### One Command Install (New)
+---
 
-Auto configure FSB in any supported MCP client:
+## Diagnostics
 
-```bash
-npx -y fsb-mcp-server install --claude-desktop   # Claude Desktop
-npx -y fsb-mcp-server install --claude-code      # Claude Code
-npx -y fsb-mcp-server install --cursor           # Cursor
-npx -y fsb-mcp-server install --vscode           # VS Code
-npx -y fsb-mcp-server install --windsurf         # Windsurf
-npx -y fsb-mcp-server install --cline            # Cline
-npx -y fsb-mcp-server install --zed              # Zed
-npx -y fsb-mcp-server install --gemini           # Gemini CLI
-npx -y fsb-mcp-server install --codex            # OpenAI Codex
-npx -y fsb-mcp-server install --continue         # Continue
-```
-
-Install to all detected platforms at once:
+Start with diagnostics before reinstalling:
 
 ```bash
-npx -y fsb-mcp-server install --all
+npx -y fsb-mcp-server doctor
+npx -y fsb-mcp-server status
+npx -y fsb-mcp-server status --watch
+npx -y fsb-mcp-server wait-for-extension
 ```
 
-Preview without writing:
+Recommended release or host smoke flow:
 
 ```bash
-npx -y fsb-mcp-server install --all --dry-run
+npm run test:mcp-smoke
+npx -y fsb-mcp-server doctor
+npx -y fsb-mcp-server status --watch
 ```
 
-Remove FSB from a platform:
+`doctor` reports the primary failing layer: package, bridge, extension, active tab, content script, or configuration. Only restart or reinstall the client when the reported layer points there.
 
-```bash
-npx -y fsb-mcp-server uninstall --cursor
-```
+### Common Failure Modes
 
-#### Post install host notes
+| Symptom | First check |
+|---------|-------------|
+| No tools in client | Confirm the client config and restart/reload the host. |
+| Tools exist but all calls fail | Run `doctor` and confirm the extension is connected. |
+| Page reads fail | Make sure the active tab is a normal webpage, not `chrome://`, `edge://`, or the web store. |
+| Clicks do nothing | Refresh DOM refs with `get_dom_snapshot`, then try `click_at` or `execute_js` where appropriate. |
+| A task is stuck | Use `get_task_status`, then `stop_task` if it is still running. |
+| Visual overlay remains | Call `end_visual_session` with the latest token, or reload the tab. |
 
-- Claude Code: `claude mcp add --scope user ...` is the cross project install path
-- Codex: edit `~/.codex/config.toml`, then restart Codex or reload the MCP server list
-- VS Code: after editing `mcp.json`, trust/start the server in the MCP view if prompted
-- Cursor: restart Cursor after editing `~/.cursor/mcp.json`
-- Windsurf: after editing either supported config path, refresh or reload the client
-- OpenCode: manual fallback only via the `mcp` JSON snippet above
-- OpenClaw: manual / unsupported until its MCP surface stabilizes
+For local development, run `npm --prefix mcp run build` after TypeScript changes. The root `npm run test:mcp-smoke` command builds the MCP package before exercising lifecycle and tool smoke tests.
 
-### Helpers
+### Restricted Tabs
 
-```bash
-npx -y fsb-mcp-server setup              # Print manual install snippets
-npx -y fsb-mcp-server status             # Show bridge and extension status
-npx -y fsb-mcp-server status --watch     # Live bridge diagnostics
-npx -y fsb-mcp-server doctor             # Diagnose the primary failed layer
-npx -y fsb-mcp-server wait-for-extension # Wait for extension to connect
-```
+Chrome blocks content script injection on browser-internal pages and some privileged surfaces. When that happens, page-reading and interaction tools will report a restricted-tab recovery message instead of pretending the page is empty.
 
-### Troubleshooting
+Safe recovery tools usually include:
 
-When MCP stops working, start with the built in diagnostics before reinstalling:
+- `list_tabs`
+- `open_tab`
+- `switch_tab`
+- `navigate`
+- `go_back`
+- `go_forward`
+- `refresh`
 
-1. `npx -y fsb-mcp-server doctor`
-2. `npx -y fsb-mcp-server status --watch`
-
-Move on to manual restart or reinstall only if the reported layer points to package drift, bridge ownership, or extension attachment. If `doctor` reports configuration or content script trouble, fix that layer first instead of cycling the whole setup.
-
-### Release Smoke
-
-Before tagging a release or debugging a fresh host setup from this repo checkout, run the short smoke flow in order:
-
-1. `npm run test:mcp-smoke`
-2. `npx -y fsb-mcp-server doctor`
-3. `npx -y fsb-mcp-server status --watch`
-4. Only then use the host specific refresh, reload, or restart step documented above
-
-This keeps automated lifecycle/tool smoke and operator facing diagnostics aligned. Do not jump straight to "restart everything" loops.
+Move to a normal `http` or `https` page before calling DOM tools such as `read_page`, `get_dom_snapshot`, or `click`.
 
 ---
 
 ## Visual Session Lifecycle
 
-Use the explicit visual session flow when your MCP client already owns the browser steps and only wants FSB to show the trusted glow, badge, and final freeze states. If you want FSB to decide and execute the steps for you, use `run_task` instead.
+Use visual sessions when your MCP client controls the browser but you still want FSB's visible trusted overlay.
 
-### Choose The Right Flow
-
-| Use case | Better fit |
-|----------|------------|
-| FSB should decide the steps and drive the browser end to end | `run_task` |
-| Your MCP client is deciding the steps; you only want FSB's visible overlay and trusted client badge while you call manual tools | `start_visual_session` + manual tools + `end_visual_session` |
-| Your runtime can also emit FSB task status tools and you want the glow to show progress and final outcome states | `start_visual_session` + `report_progress` / `complete_task` / `partial_task` / `fail_task` + optional `end_visual_session` |
-
-### Trusted Client Labels
-
-`start_visual_session` accepts only fixed trusted labels from FSB's allowlist. Common examples include `Claude`, `Codex`, `ChatGPT`, `Gemini`, `Cursor`, `Windsurf`, `Perplexity`, `Grok`, `OpenCode`, `OpenClaw`, and `Antigravity`. Arbitrary badge text or custom branding is rejected.
-
-### Minimal Public Flow
-
-The simplest pattern for MCP clients that want the glow and badge without handing control to autopilot:
-
-1. Call `start_visual_session` with `client` and `task`.
-2. Drive the page with normal manual tools such as `navigate`, `click`, `type_text`, `press_enter`, or `scroll`.
-3. Call `end_visual_session` with the returned `session_token` when you want to clear the glow explicitly.
+1. Call `start_visual_session` with a trusted client label such as `Codex`, `Claude`, `ChatGPT`, `Gemini`, `Cursor`, `Windsurf`, `OpenCode`, `OpenClaw`, `Grok`, `Perplexity`, or `Antigravity`.
+2. Drive the page with manual tools.
+3. Call `end_visual_session` with the returned `session_token`.
 
 Example:
 
 ```text
 start_visual_session(client="Codex", task="Complete checkout", detail="Preparing cart")
--> returns session_token="visual_token_123"
-
 navigate(url="https://example.com/cart")
 click(selector="text=Checkout")
 type_text(selector="#email", text="user@example.com")
-
 end_visual_session(session_token="visual_token_123", reason="ended")
 ```
 
-### Extended Progress And Finalization
+Use `run_task` only when the user explicitly wants FSB autopilot to decide and execute the steps.
 
-If your runtime also has access to FSB's shared task status tools, keep the same `session_token` threaded through:
+### Manual Tool Selection
 
-1. `start_visual_session(client, task, detail?)`
-2. Zero or more `report_progress(session_token, message, progress_percent?)`
-3. One final outcome call:
-   - `complete_task(session_token, summary, detail?)`
-   - `partial_task(session_token, summary, blocker, next_step, reason?)`
-   - `fail_task(session_token, reason, detail?)`
-4. `end_visual_session(session_token)` only when you still need an explicit clear or cancel after your own flow
+For most browser work, start read-only and then choose the smallest mutating tool:
+
+- Use `read_page` when text is enough.
+- Use `get_dom_snapshot` when selectors, inputs, forms, buttons, and refs matter.
+- Use `get_page_snapshot` when an agent needs a compact planning view.
+- Use `get_site_guide` when a site has known workflow quirks or selectors.
+- Use `execute_js` for robust DOM reads and simple DOM-triggered actions.
+- Use native tools such as `type_text`, `press_key`, `click`, and `drag` when frameworks need real events.
+- Use coordinate tools for canvas, maps, overlays, and controls that do not expose useful DOM selectors.
+
+Manual mode keeps the external AI client in control. Autopilot mode delegates control to FSB's internal loop and is better for user requests that explicitly say to let FSB run the task.
+
+### Queueing Model
+
+Mutation tools are serialized through a task queue. This prevents overlapping browser actions when multiple clients or repeated calls arrive close together. Read-only tools can bypass the queue where safe, allowing status or page inspection while a longer mutation is running.
+
+Longer-running tools have timeout overrides. For example, spreadsheet operations can take more time than a normal click because they may type many cells. Autopilot also has a longer timeout because it runs multiple turns inside the extension.
+
+---
+
+## Tools (59 Total)
+
+### Visual Sessions (2)
+
+| Tool | Purpose |
+|------|---------|
+| `start_visual_session` | Show the trusted glow/overlay and return a session token. |
+| `end_visual_session` | Clear a client-owned visual session. |
+
+### Autopilot (3)
+
+| Tool | Purpose |
+|------|---------|
+| `run_task` | Let FSB's AI perform a natural language browser task end to end. |
+| `stop_task` | Cancel the active automation task. |
+| `get_task_status` | Check task progress, phase, and ETA. |
+
+### Manual Browser Control (37)
+
+| Group | Tools |
+|-------|-------|
+| Power | `execute_js` |
+| Navigation | `navigate`, `search`, `go_back`, `go_forward`, `refresh` |
+| Interaction | `click`, `type_text`, `press_enter`, `press_key`, `select_option`, `check_box`, `hover`, `right_click`, `double_click`, `select_text_range`, `drag_drop`, `drop_file`, `focus`, `clear_input` |
+| Scrolling and waiting | `scroll`, `scroll_to_top`, `scroll_to_bottom`, `scroll_to_element`, `wait_for_element`, `wait_for_stable` |
+| Tabs | `open_tab`, `switch_tab` |
+| Spreadsheets | `fill_sheet` |
+| Coordinates and mutation | `click_at`, `click_and_hold`, `drag`, `drag_variable_speed`, `scroll_at`, `insert_text`, `double_click_at`, `set_attribute` |
 
 Notes:
 
-- `session_token` is the ownership key for the visible lifecycle. Reuse the latest token returned by `start_visual_session`.
-- Final outcome calls preserve the short frozen overlay before the glow clears.
-- `partial_task` fits useful partial work plus an external blocker, especially login or manual approval handoffs.
-- `report_progress` is narration only. It does not click, type, navigate, or submit by itself.
+- `execute_js` is powerful but should still be verified with a read-only tool after it changes page state.
+- `type_text` is preferred over setting `.value` manually for React, Angular, Vue, and similar controlled inputs.
+- `select_option` only targets native `<select>` elements; use click patterns for custom dropdowns.
+- `fill_sheet` can take longer than normal tools and uses a longer timeout.
+
+### Read Only (8)
+
+| Tool | Purpose |
+|------|---------|
+| `read_page` | Read visible page text. |
+| `get_text` | Read text from a selected element. |
+| `get_attribute` | Read an attribute from a selected element. |
+| `get_dom_snapshot` | Get structured DOM elements, refs, selectors, and forms. |
+| `get_page_snapshot` | Get a compact page snapshot for agent planning. |
+| `get_site_guide` | Retrieve site-specific automation guidance. |
+| `list_tabs` | List open tabs. |
+| `read_sheet` | Read spreadsheet ranges. |
+
+### Observability (5)
+
+| Tool | Purpose |
+|------|---------|
+| `list_sessions` | List past automation sessions. |
+| `get_session_detail` | Inspect a specific session. |
+| `get_logs` | Read recent or session-scoped logs. |
+| `search_memory` | Search FSB memory for relevant past experience. |
+| `get_memory_stats` | Inspect memory counts and storage usage. |
+
+### Vault (4)
+
+| Tool | Purpose |
+|------|---------|
+| `list_credentials` | List saved credential metadata without passwords. |
+| `fill_credential` | Fill a login form with an unlocked saved credential. |
+| `list_payment_methods` | List saved payment metadata without full card data. |
+| `use_payment_method` | Fill checkout data after user confirmation. |
+
+Vault responses expose metadata only. Passwords, full card numbers, and CVV values are resolved inside the extension and are not returned to the MCP client.
+
+### Tool Count Contract
+
+The public count is intentionally based on registered MCP handlers, not every internal helper in the extension. The extension's canonical registry also contains task-lifecycle signals and internal context tools used by the browser runtime. The MCP README documents the tool surface an MCP client can call.
 
 ---
 
-## Tools (62 total)
-
-### Visual Sessions (2 tools)
-
-Use these when your MCP client wants the visible glow and badge without handing control to `run_task`.
-
-| Tool | Description |
-|------|-------------|
-| `start_visual_session` | Start the visible FSB overlay on the active normal webpage and return a `session_token` for follow up lifecycle calls. |
-| `end_visual_session` | Clear a client owned visual session explicitly using its `session_token`, without invoking autopilot completion. |
-
-### Autopilot (3 tools)
-
-Let FSB's AI handle the entire task autonomously.
-
-| Tool | Description |
-|------|-------------|
-| `run_task` | Execute a browser automation task via natural language. FSB's AI decides the steps. |
-| `stop_task` | Cancel the currently running automation task. |
-| `get_task_status` | Check task progress, current phase, and ETA. |
-
-### Manual: Navigation (5 tools)
-
-| Tool | Description |
-|------|-------------|
-| `navigate` | Open a URL in the active tab. Returns final URL after redirects. |
-| `search` | Trigger a search on the current page. |
-| `go_back` | Navigate back one page in browser history. |
-| `go_forward` | Navigate forward one page in browser history. |
-| `refresh` | Reload the current page. |
-
-### Manual: Interaction (14 tools)
-
-| Tool | Description |
-|------|-------------|
-| `click` | Click an element by CSS selector or element reference. |
-| `type_text` | Type text into an input field. |
-| `press_enter` | Press Enter, optionally on a specific element. |
-| `press_key` | Press a key with optional modifiers (ctrl, shift, alt). |
-| `select_option` | Select an option from a dropdown. |
-| `check_box` | Toggle a checkbox. |
-| `hover` | Hover over an element to trigger menus or tooltips. |
-| `right_click` | Open context menu on an element. |
-| `double_click` | Double click an element. |
-| `select_text_range` | Select a substring within an element by character offsets. |
-| `drag_drop` | Drag and drop one DOM element onto another (3 method fallback). |
-| `drop_file` | Simulate dropping a file onto a dropzone element. |
-| `focus` | Move keyboard focus to an element. |
-| `clear_input` | Clear the contents of an input field. |
-
-### Manual: Scrolling (5 tools)
-
-| Tool | Description |
-|------|-------------|
-| `scroll` | Scroll up or down by a specified amount. |
-| `scroll_to_top` | Scroll to the top of the page. |
-| `scroll_to_bottom` | Scroll to the bottom of the page. |
-| `scroll_to_element` | Scroll a specific element into view. |
-| `wait_for_stable` | Wait until the page stops changing (no DOM mutations). |
-
-### Manual: Tabs (2 tools)
-
-| Tool | Description |
-|------|-------------|
-| `open_tab` | Open a new tab with a URL. Returns the tab ID. |
-| `switch_tab` | Switch to a tab by ID. |
-
-### Manual: Spreadsheets (2 tools)
-
-| Tool | Description |
-|------|-------------|
-| `fill_sheet` | Fill spreadsheet cells with CSV data starting from a given cell. |
-| `read_sheet` | Read cell values from a spreadsheet range. |
-
-### Manual: CDP Coordinate Tools (8 tools)
-
-For canvas elements, overlays, and cases where DOM selectors do not work.
-
-| Tool | Description |
-|------|-------------|
-| `click_at` | Click at viewport coordinates using CDP trusted events. Supports modifiers. |
-| `click_and_hold` | Click and hold at coordinates for a duration (long press, record buttons). |
-| `drag` | Drag between two viewport coordinates (canvas drawing, sliders, maps). |
-| `drag_variable_speed` | Drag with ease in out timing curve (human like motion). |
-| `scroll_at` | Mouse wheel at coordinates (map zoom, canvas zoom). |
-| `double_click_at` | Double click at viewport coordinates using CDP trusted events. |
-| `insert_text` | Insert text via CDP into the currently focused editable target. |
-| `wait_for_element` | Wait until an element matching a selector appears on the page. |
-
-### Manual: DOM Mutation Helper (1 tool)
-
-| Tool | Description |
-|------|-------------|
-| `set_attribute` | Set an HTML attribute value on a specific element. |
-
-### Read Only (5 tools)
-
-These bypass the mutation queue for concurrent access.
-
-| Tool | Description |
-|------|-------------|
-| `read_page` | Read the text content of the current page. |
-| `get_text` | Get text content of a specific element. |
-| `get_attribute` | Get an HTML attribute value from an element. |
-| `get_dom_snapshot` | Get structured DOM snapshot with element references and selectors. |
-| `list_tabs` | List all open tabs with title, URL, and active status. |
-
-### Observability (5 tools)
-
-Inspect past sessions and FSB's learned memory.
-
-| Tool | Description |
-|------|-------------|
-| `list_sessions` | List all past automation sessions with summary info. |
-| `get_session_detail` | Get full session detail: logs, action history, timing. |
-| `get_logs` | Get recent logs or session specific logs with error summary. |
-| `search_memory` | Search FSB's memory for past experiences on similar sites. |
-| `get_memory_stats` | Get memory system statistics: count, types, storage usage. |
-
-### Agents (8 tools)
-
-Manage and run scheduled background agents directly over MCP.
-
-| Tool | Description |
-|------|-------------|
-| `create_agent` | Create a new background agent with schedule and start mode. |
-| `list_agents` | List all configured background agents. |
-| `run_agent` | Trigger immediate execution of an agent. |
-| `stop_agent` | Stop a currently running agent execution. |
-| `delete_agent` | Permanently delete an agent. |
-| `toggle_agent` | Enable or disable an agent. |
-| `get_agent_stats` | Get aggregate stats across all agents. |
-| `get_agent_history` | Get recent run history for one agent. |
-
-### Vault (4 tools)
-
-Secure access to saved credentials and payment methods. Raw secrets never cross the MCP bridge.
-
-| Tool | Description |
-|------|-------------|
-| `list_credentials` | List saved credentials (domain + username only, passwords never included). |
-| `fill_credential` | Auto fill a login form with a saved credential on the active tab. |
-| `list_payment_methods` | List saved payment methods (last 4 digits + brand only). |
-| `use_payment_method` | Fill a checkout form with a saved payment method after user confirmation. |
-
----
-
-## Configuration
-
-The MCP server talks to the FSB Chrome Extension over a local WebSocket on port **7225**. No configuration is needed for the extension bridge. Just install and enable the extension, and keep the browser running.
-
-If you run local Streamable HTTP mode, the MCP client talks to `http://127.0.0.1:7226/mcp` by default while the extension keeps using `ws://localhost:7225`.
-
-### How it works
+## Architecture
 
 ```mermaid
 graph TD
-    A["MCP Client\n(Claude Desktop / Claude Code / Cursor / Windsurf)"] -->|"stdio or local Streamable HTTP"| B["FSB MCP Server\n(this package)"]
-    B -->|"WebSocket (port 7225)"| C["FSB Chrome Extension\n(your browser)"]
-    C -->|"DOM Analysis + Action Execution"| D["Any Website"]
+    A["MCP Client"] -->|"stdio or Streamable HTTP"| B["fsb-mcp-server"]
+    B -->|"WebSocket ws://localhost:7225"| C["FSB Chrome Extension"]
+    C -->|"DOM analysis + action execution"| D["Active Web Page"]
 
-    subgraph tools ["MCP Tool Groups"]
-        direction LR
-        T0["Visual Sessions\n2 tools"]
-        T1["Autopilot\n3 tools"]
-        T2["Manual\n37 tools"]
-        T6["Read Only\n5 tools"]
-        T7["Observability\n5 tools"]
-        T8["Agents\n8 tools"]
-        T9["Vault\n4 tools"]
+    subgraph Surface["Tool Surface"]
+      V["Visual sessions"]
+      M["Manual tools"]
+      R["Read-only tools"]
+      O["Observability"]
+      P["Vault"]
+      T["Autopilot"]
     end
 
-    B --- tools
+    B --- Surface
 ```
 
-### Hub/Relay Architecture
+Multiple MCP clients can connect at once. The first server instance becomes the hub on port 7225; later instances become relay clients. If the hub exits, a relay can promote to hub.
 
-FSB uses the same local bridge contract:
+The server also exposes live resources:
 
-- The MCP client talks to this package over stdio or Streamable HTTP
-- This package talks to the extension over `ws://localhost:7225`
-- The browser extension is unchanged
+| Resource | URI |
+|----------|-----|
+| Current Page DOM | `browser://dom/snapshot` |
+| Open Tabs | `browser://tabs` |
+| Site Guides | `fsb://site-guides` |
+| FSB Memory | `fsb://memory` |
+| Extension Config | `fsb://config` |
 
-This keeps installation simple while avoiding any MCP specific changes inside the extension.
-
-Multiple MCP clients can connect at once. The first server instance becomes the **hub** (listens on port 7225). Additional instances connect as **relay clients** to the hub. If the hub disconnects, a relay automatically promotes to hub.
+Resources are read-only views intended to help agents understand the browser state without issuing an action. They are complementary to tools; they do not replace the tool calls needed for navigation or interaction.
 
 ---
 
-## Resources
+## Development
 
-The server also exposes 5 live MCP resources:
+From the repo root:
 
-| Resource | URI | Description |
-|----------|-----|-------------|
-| Current Page DOM | `browser://dom/snapshot` | Structured DOM with element references |
-| Open Tabs | `browser://tabs` | All tabs with title, URL, active status |
-| Site Guides | `fsb://site-guides` | Domain specific automation intelligence |
-| FSB Memory | `fsb://memory` | Learned patterns from past sessions |
-| Extension Config | `fsb://config` | Current settings and connection status |
+```bash
+npm --prefix mcp install
+npm --prefix mcp run build
+npm run test:mcp-smoke
+```
+
+Useful package commands:
+
+```bash
+npm --prefix mcp run dev
+npm --prefix mcp run doctor
+npm --prefix mcp run status
+npm --prefix mcp run serve
+```
+
+Release checks should verify:
+
+- `mcp/src/version.ts` and `mcp/package.json` agree.
+- `mcp/README.md` tool counts match the registered runtime surface.
+- `mcp/src/tools/schema-bridge.ts` still loads the generated `ai/tool-definitions.cjs`.
+- Root tests still cover route contracts and setup guidance.
+- The npm package includes `build/`, `ai/`, `README.md`, and `server.json`.
+
+### Package Contents
+
+The npm package publishes built JavaScript from `build/`, the copied CommonJS tool definitions under `ai/`, package metadata, `server.json`, and this README. The TypeScript source remains in the repository.
+
+The build command copies `extension/ai/tool-definitions.js` into `mcp/ai/tool-definitions.cjs`. That keeps the MCP server aligned with the extension action registry without duplicating schemas by hand.
+
+### Versioning
+
+The MCP package has its own version (`0.7.4`) because it is published independently from the extension release (`0.9.50`). When extension bridge contracts change, update both the MCP version metadata and the compatibility notes in this README. When only website or extension UI text changes, the MCP version usually does not need to move.
+
+Contract-sensitive changes should be covered by tests before publishing:
+
+- route names and bridge message types
+- parameter transforms between MCP names and FSB internal action names
+- installer platform config writers
+- restricted-tab recovery messages
+- visual-session token lifecycle
+- vault redaction boundaries
 
 ---
 
 ## Links
 
-- [FSB Chrome Extension](https://github.com/LakshmanTurlapati/FSB): the browser extension this server connects to
-- [Issues](https://github.com/LakshmanTurlapati/FSB/issues): report bugs or request features
-- [License](https://github.com/LakshmanTurlapati/FSB/blob/main/LICENSE): BSL 1.1
-
----
+- [FSB Chrome Extension](https://github.com/LakshmanTurlapati/FSB)
+- [npm package](https://www.npmjs.com/package/fsb-mcp-server)
+- [Issues](https://github.com/LakshmanTurlapati/FSB/issues)
+- [License](https://github.com/LakshmanTurlapati/FSB/blob/main/LICENSE)
 
 <div align="center">
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/assets/fsb_logo_dark_footer.png" />
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/assets/fsb_logo_light_footer.png" />
-  <img src="https://raw.githubusercontent.com/LakshmanTurlapati/FSB/main/assets/fsb_logo_light_footer.png" alt="FSB" width="80" />
-</picture>
 
 *Built by [Lakshman Turlapati](https://github.com/LakshmanTurlapati)*
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -1,61 +1,83 @@
 # FSB Showcase
 
-The marketing site at [full-selfbrowsing.com](https://full-selfbrowsing.com).
+`showcase/` contains the public site for [full-selfbrowsing.com](https://full-selfbrowsing.com) plus the production Express relay used by dashboard pairing.
 
 ## Layout
 
 | Path | Purpose |
 |------|---------|
-| `angular/` | Angular 19 site with SSR and prerender for `/`, `/about`, `/privacy`, `/support`. |
-| `server/` | Express + better-sqlite3 + ws deploy backend (handles dashboard pairing + relay). |
-| `assets/` | Static images, logos, screenshots referenced by the prerendered HTML. |
-| `css/`, `js/`, `*.html` | Legacy static surfaces still served alongside the Angular app (privacy, about, dashboard). |
-| `dist/` | Build output (gitignored). Populated by `angular/` build. |
+| `angular/` | Angular 20 app with static prerender for `/`, `/about`, `/privacy`, and `/support`. |
+| `server/` | Express + better-sqlite3 + ws backend for pairing, auth, relay, and dashboard data. |
+| `assets/` | Images, logos, icons, and provider artwork copied into the Angular build. |
+| `css/`, `js/`, `*.html` | Legacy static surfaces still kept beside the Angular app. |
+| `dist/` | Build output, populated as `showcase/dist/showcase-angular/`. |
 
 ## Develop
 
 ```bash
-cd angular
+cd showcase/angular
 npm install
 npm start
 ```
 
-The dev server runs at `http://localhost:4200` with hot reload.
+The dev server runs at `http://localhost:4200`.
 
 ## Build
 
 ```bash
-npm --prefix angular run build
+npm --prefix showcase/angular run build
 ```
 
-Runs Angular's SSR + prerender pipeline for the static routes. Output lands in `angular/dist/`.
-
-The `prebuild` lifecycle hook also runs `angular/scripts/build-crawler-files.mjs`, which generates the SEO/GEO surfaces:
+The Angular build prerenders the static routes and runs `scripts/build-crawler-files.mjs` first, generating:
 
 - `/robots.txt`
 - `/sitemap.xml`
 - `/llms.txt`
 - `/llms-full.txt`
 
-`Organization` and `SoftwareApplication` JSON-LD blocks are baked into every prerendered HTML page. See `.planning/milestones/v0.9.46-ROADMAP.md` for the SEO/GEO milestone history.
+Production assets are emitted under `showcase/dist/showcase-angular/`.
 
-## Deploy
+The Angular config copies `showcase/assets/` into the built `/assets` path and includes the public crawler files from `angular/public/`.
 
-Production runs on fly.io. The repo root `fly.toml` and `Dockerfile` build a container that serves `showcase/server/server.js` (Express + WebSocket relay).
+## Routes
 
-Pushes to `main` trigger `.github/workflows/deploy.yml`, which runs `flyctl deploy --remote-only`. No manual steps required.
+Static prerender currently covers:
 
-## Smoke Test
+- `/`
+- `/about`
+- `/privacy`
+- `/support`
 
-After deploy, hit production with a crawler user agent to confirm prerender + JSON-LD survived:
+Crawler-facing files are generated from `angular/scripts/build-crawler-files.mjs` and source content in `angular/scripts/llms-full.source.md`.
+
+## Deploy And Smoke
+
+The root `Dockerfile` and `fly.toml` deploy `showcase/server/server.js` on fly.io. Pushes to `main` trigger `.github/workflows/deploy.yml`.
+
+Runtime defaults:
+
+- `PORT=3847`
+- `DB_PATH=/data/fsb-data.db`
+- `NODE_ENV=production`
+
+The production container is built in two stages. The first stage builds the Angular static output. The final stage installs server dependencies, copies the Express source, copies the Angular browser output into `public/`, and creates `/data` for SQLite persistence.
+
+## Server Responsibilities
+
+The Express backend handles:
+
+- dashboard pairing
+- authenticated dashboard routes
+- WebSocket relay behavior
+- SQLite persistence for paired dashboard state
+- serving prerendered Angular assets in production
+
+Post-deploy crawler checks:
 
 ```bash
 curl -A GPTBot -sI https://full-selfbrowsing.com/ | head -1
 curl -A GPTBot -s  https://full-selfbrowsing.com/llms.txt | head -5
+npm --prefix showcase/angular run smoke:crawler
 ```
 
-The npm helper `npm --prefix angular run smoke:crawler` runs the full crawler smoke matrix used in the v0.9.46 UAT.
-
-## Repository Layout
-
-See the root [`README.md`](../README.md) for the full repo overview, including the Chrome extension (`extension/`) and MCP server (`mcp/`).
+See the root [README.md](../README.md) for the full repository overview.


### PR DESCRIPTION
## Summary

- Refresh the root README for v0.9.50 with the current repository layout, setup flow, feature surface, and development commands.
- Update package READMEs for `extension/`, `mcp/`, and `showcase/` so docs match the current split-package structure.
- Clarify current MCP versioning, install guidance, and package ownership notes.

## Validation

- `npm run ci`
