### PR TITLE
ci(extension): add Chrome extension release packaging

### DIFF
--- a/.github/workflows/chrome-extension.yml
+++ b/.github/workflows/chrome-extension.yml
@@ -1,0 +1,57 @@
+name: chrome-extension
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'extension/**'
+      - 'scripts/package-extension.mjs'
+      - 'scripts/validate-extension.mjs'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'mcp/**'
+      - '.github/workflows/chrome-extension.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: chrome-extension-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: validate, test, package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install root deps
+        run: npm install --no-audit --no-fund
+
+      - name: Install mcp deps
+        run: npm --prefix mcp install --no-audit --no-fund
+
+      - name: Validate extension
+        run: npm run validate:extension
+
+      - name: Run extension and bridge tests
+        run: npm test
+
+      - name: Package Chrome extension
+        run: npm run package:extension
+
+      - name: Read extension version
+        id: extension_version
+        run: |
+          node -e "const { version } = require('./extension/manifest.json'); console.log('version=' + version)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Chrome extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fsb-extension-v${{ steps.extension_version.outputs.version }}
+          path: dist/fsb-extension-v*.zip
+          if-no-files-found: error

--- a/extension/README.md
+++ b/extension/README.md
@@ -67,6 +67,8 @@ The extension is driven through:
 
 ## Packaging Note
 
-The root `npm run package` command currently creates a repository-level zip named for the release version. Review the archive contents before using it as a Chrome Web Store submission package.
+Use `npm run package:extension` from the repository root to create a Chrome Web Store-ready archive at `dist/fsb-extension-v<version>.zip`. The archive contains the contents of `extension/` at the zip root, so `manifest.json` is not nested under an extra directory.
+
+The legacy root `npm run package` command creates a repository-level zip and should not be used for Chrome Web Store submission packages.
 
 See the root [README.md](../README.md) for full repo setup, MCP usage, and showcase deployment context.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -4,6 +4,11 @@
   "description": "FSB Browser Automation MCP Server",
   "license": "BUSL-1.1",
   "author": "Lakshman Turlapati",
+  "contributors": [
+    {
+      "name": "OpenAI Codex"
+    }
+  ],
   "mcpName": "io.github.lakshmanturlapati/fsb-mcp-server",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "echo \"Linting not configured yet\"",
     "clean": "rm -f config/dev-settings.json",
     "package": "zip -r fsb-v0.9.50.zip . -x '*.git*' 'node_modules/*' 'config/dev-*'",
+    "package:extension": "node scripts/package-extension.mjs",
     "showcase:install": "npm --prefix showcase/angular install",
     "showcase:build": "npm --prefix showcase/angular run build",
     "showcase:serve": "npm --prefix showcase/angular run start",
@@ -59,6 +60,9 @@
       "name": "Lakshman Turlapati",
       "email": "lakshman@example.com",
       "url": "https://github.com/lakshmanturlapati"
+    },
+    {
+      "name": "OpenAI Codex"
     }
   ],
   "license": "BUSL-1.1",

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Builds the Chrome Web Store-ready archive from extension/ only.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const EXT_ROOT = join(ROOT, 'extension');
+const DIST_DIR = join(ROOT, 'dist');
+
+function fail(message) {
+  console.error(`package-extension: ${message}`);
+  process.exit(1);
+}
+
+const manifestPath = join(EXT_ROOT, 'manifest.json');
+if (!existsSync(manifestPath)) {
+  fail('extension/manifest.json not found');
+}
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+} catch (error) {
+  fail(`extension/manifest.json is not valid JSON: ${error.message}`);
+}
+
+if (!/^(\d+\.){2,3}\d+$/.test(manifest.version || '')) {
+  fail(`extension/manifest.json version "${manifest.version}" is not a Chrome extension version`);
+}
+
+mkdirSync(DIST_DIR, { recursive: true });
+
+const zipName = `fsb-extension-v${manifest.version}.zip`;
+const zipPath = join(DIST_DIR, zipName);
+rmSync(zipPath, { force: true });
+
+const excludes = [
+  '.DS_Store',
+  '*/.DS_Store',
+  '*.log',
+  '*.tmp',
+  '*.temp',
+  '*.pem',
+  'config/secrets.json',
+  'config/dev-*',
+  'config/local-*',
+  'node_modules/*',
+  'dist/*',
+  'build/*',
+];
+
+try {
+  execFileSync('zip', ['-r', '-q', zipPath, '.', '-x', ...excludes], {
+    cwd: EXT_ROOT,
+    stdio: 'inherit',
+  });
+} catch (error) {
+  if (error.code === 'ENOENT') {
+    fail('zip CLI is required to build the extension archive');
+  }
+  process.exit(error.status || 1);
+}
+
+console.log(`package-extension: wrote ${zipPath.replace(`${ROOT}/`, '')}`);


### PR DESCRIPTION
## Summary

- Adds a main-branch Chrome extension workflow that validates, tests, packages, and uploads the extension ZIP as an Actions artifact.
- Adds an extension-only packaging command that keeps manifest.json at the archive root.
- Adds OpenAI Codex as a contributor in package metadata.

## Validation

- npm run validate:extension
- npm --prefix mcp run build
- npm run package:extension
- npm test