### PR TITLE
docs: add Quick Start TL;DR to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ Project Mariner, Claude Computer Use, and OpenAI Operator rely heavily on visual
 | Typical per step latency | 1 to 3 seconds | 50 to 200 ms |
 | Token/cost profile | Image heavy | Text/structure heavy |
 
+### Quick Start TL;DR
+
+**FSB shines when your AI client drives it directly.** Install the MCP server for your client of choice — one command, no manual config edits, and **no FSB API key needed** (your MCP client's model handles the reasoning):
+
+| Client | One-command install |
+|--------|---------------------|
+| Claude Code | `npx -y fsb-mcp-server install --claude-code` |
+| Claude Desktop | `npx -y fsb-mcp-server install --claude-desktop` |
+| Cursor | `npx -y fsb-mcp-server install --cursor` |
+| VS Code | `npx -y fsb-mcp-server install --vscode` |
+| Windsurf | `npx -y fsb-mcp-server install --windsurf` |
+| Codex | `npx -y fsb-mcp-server install --codex` |
+| All at once | `npx -y fsb-mcp-server install --all` |
+
+Preview before writing: append `--dry-run`. Sanity check with `npx -y fsb-mcp-server doctor`. Restart the client so the new MCP server appears.
+
+**Then install the browser side** (the MCP bridge talks to the extension):
+
+1. Get **FSB** from the [Chrome Web Store](https://chromewebstore.google.com/detail/badgafnfchcihdfnjneklogedcdkmjfk).
+2. From your MCP client, try: `Search for cats on Google` or `Read this page and summarize it`.
+
+Want to run FSB standalone from the extension popup/side panel? Open settings, paste an API key (xAI, Gemini, OpenAI, Anthropic, OpenRouter, LM Studio, or custom), and start there — no MCP needed.
+
 ### What It Does
 
 - Runs natural language browser tasks from the popup or side panel.


### PR DESCRIPTION
## Summary

- Adds a **Quick Start TL;DR** subsection in the Overview, between "Why DOM First" and "What It Does", so new readers get a 30-second install path without scrolling to the deeper `## Quick Start` section.
- Leads with the **MCP install path** (per-client `npx -y fsb-mcp-server install --<client>` one-liners as a table) and calls out that **no FSB API key is required** when an MCP client drives the browser.
- Points end-users at the **Chrome Web Store** listing rather than `git clone` + Load unpacked. The standalone popup/side-panel + provider-key flow remains as a one-line escape hatch.
- README-only change (+23 lines, 1 file). No behavior, version, or CHANGELOG impact. The deeper `## Quick Start`, MCP, Architecture, etc. sections are untouched.

## Test plan

- [ ] Render the README on GitHub and confirm the TL;DR sits between the comparison table and "What It Does".
- [ ] Confirm the header nav `[Quick Start](#quick-start)` link still jumps to the deeper section (the new heading slugifies to `#quick-start-tldr`).
- [ ] Spot-check the `npx -y fsb-mcp-server install --<client>` commands match the existing MCP Server section.
- [ ] Verify the Chrome Web Store URL matches `showcase/angular/src/app/pages/home/home-page.component.ts:26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)