### PR TITLE
Skill runtime fixes + agents page polish

### DIFF
--- a/showcase/angular/src/app/pages/agents/agents-page.component.html
+++ b/showcase/angular/src/app/pages/agents/agents-page.component.html
@@ -12,7 +12,7 @@
       FSB ships a polished OpenClaw skill plus a 50+ tool MCP surface that any agent runtime can drive. Click, type, orchestrate across tabs, fill vault credentials, read live page state, all from one prompt, in the user&#39;s actual Chrome.
     </p>
     <div class="agents-hero-actions reveal delay-3">
-      <a href="https://clawhub.ai/" target="_blank" rel="noopener" class="btn btn-primary">
+      <a href="https://clawhub.ai/lakshmanturlapati/full-selfbrowsing" target="_blank" rel="noopener" class="btn btn-primary">
         Install on ClawHub
       </a>
       <a href="https://github.com/lakshmanturlapati/FSB" target="_blank" rel="noopener" class="btn btn-secondary">
@@ -61,28 +61,28 @@
         <div class="power-card-stat">50+</div>
         <div class="power-card-body">
           <h3>MCP tools, one surface</h3>
-          <p>Read only first (<code>read_page</code>, <code>get_dom_snapshot</code>, <code>get_page_snapshot</code>, <code>get_site_guide</code>), interaction (<code>click</code>, <code>type_text</code>, <code>press_enter</code>), navigation, vault, and observability tools. All typed. All scoped to the calling agent.</p>
+          <p>Read, click, type, navigate, vault, observe. All typed. All agent-scoped. One surface, no glue code.</p>
         </div>
       </article>
       <article class="power-card reveal delay-2">
         <div class="power-card-stat">N agents</div>
         <div class="power-card-body">
           <h3>Multi agent identity and tab ownership</h3>
-          <p>Each MCP session gets a server minted <code>agent_id</code>. Tabs are owned per agent. Cross agent access rejects with typed <code>TAB_NOT_OWNED</code>. The concurrency cap is configurable from 1 to 64 (default 8) with a fail loud <code>AGENT_CAP_REACHED</code> error. Background tabs never steal user focus.</p>
+          <p>Server-minted <code>agent_id</code> per session. Tabs owned per agent. Cross-agent calls fail loud with <code>TAB_NOT_OWNED</code>. Cap 1-64 (default 8), <code>AGENT_CAP_REACHED</code> when full. No focus stealing.</p>
         </div>
       </article>
       <article class="power-card reveal delay-3">
         <div class="power-card-stat">0 leaks</div>
         <div class="power-card-body">
           <h3>Vault boundary, by design</h3>
-          <p>Passwords and payment details resolve inside the FSB Chrome extension&#39;s encrypted storage via <code>fill_credential</code> and <code>use_payment_method</code>. Never in chat. Never in tool args. <code>requires.env</code> is mandatory empty.</p>
+          <p>Passwords and cards resolve inside the extension&#39;s encrypted store via <code>fill_credential</code> and <code>use_payment_method</code>. Never in chat. Never in args. <code>requires.env</code> is mandatory empty.</p>
         </div>
       </article>
       <article class="power-card reveal delay-4">
         <div class="power-card-stat">Live</div>
         <div class="power-card-body">
           <h3>Real Chrome, real session</h3>
-          <p>The user&#39;s logged in cookies, extensions, and saved state are the runtime. Visual feedback shows what is being targeted. <code>change_report</code> on every action keeps the agent aware of mutations without an extra <code>read_page</code> round trip.</p>
+          <p>Your cookies. Your extensions. Your saved state. <code>change_report</code> streams mutations on every action — no extra <code>read_page</code> round-trip.</p>
         </div>
       </article>
     </div>
@@ -131,45 +131,55 @@
   </div>
 </section>
 
-<!-- Try it -->
+<!-- What people actually automate -->
 <section class="section agents-try">
   <div class="container">
     <div class="section-header reveal">
-      <h2>Try It</h2>
-      <p>Once the doctor is green, paste any of these into your OpenClaw chat to confirm the loop works.</p>
+      <h2>Where FSB <span class="text-orange">earns its keep</span></h2>
+      <p>The recurring browser work. The boring, repetitive stuff that vision-based agents struggle with on logged-in sites. FSB runs in the user&#39;s real Chrome, so cookies, sessions, MFA state, and saved logins are already there.</p>
     </div>
 
-    <div class="try-mode reveal delay-1">
-      <h3>Manual mode (default)</h3>
-      <p>Each prompt calls a single FSB tool so you can see the round trip plainly.</p>
-      <ul class="try-list">
-        <li>
-          <span class="try-tool"><code>read_page</code></span>
-          <span class="try-prompt">&quot;Open https://example.com and read the page. Summarize the visible text in two sentences.&quot;</span>
-        </li>
-        <li>
-          <span class="try-tool"><code>click</code></span>
-          <span class="try-prompt">&quot;On https://example.com, click the &#39;More information...&#39; link and tell me what page loads.&quot;</span>
-        </li>
-        <li>
-          <span class="try-tool"><code>type_text</code></span>
-          <span class="try-prompt">&quot;Open https://duckduckgo.com, type <code>fsb-mcp-server</code> into the search box, and press Enter. Then list the first three result titles.&quot;</span>
-        </li>
-      </ul>
+    <div class="prompt-grid">
+      <article class="prompt-card reveal delay-1">
+        <header class="prompt-card-head">
+          <span class="prompt-card-icon"><i class="ph ph-tray"></i></span>
+          <span class="prompt-card-label">Inbox triage</span>
+        </header>
+        <p class="prompt-card-body"><span class="prompt-caret">&gt;</span>Open Gmail, label everything from billing as <code>finance</code>, draft replies to support threads using yesterday&#39;s tone, and flag anything urgent.</p>
+      </article>
+      <article class="prompt-card reveal delay-2">
+        <header class="prompt-card-head">
+          <span class="prompt-card-icon"><i class="ph ph-headset"></i></span>
+          <span class="prompt-card-label">Support replies</span>
+        </header>
+        <p class="prompt-card-body"><span class="prompt-caret">&gt;</span>In Zendesk, draft answers to open tickets about pricing, order status, and shipping using the help center as ground truth.</p>
+      </article>
+      <article class="prompt-card reveal delay-3">
+        <header class="prompt-card-head">
+          <span class="prompt-card-icon"><i class="ph ph-chart-line-up"></i></span>
+          <span class="prompt-card-label">Logged-in dashboards</span>
+        </header>
+        <p class="prompt-card-body"><span class="prompt-caret">&gt;</span>Pull yesterday&#39;s revenue, signups, and refund count from the analytics dashboard and post a one paragraph summary.</p>
+      </article>
+      <article class="prompt-card reveal delay-4">
+        <header class="prompt-card-head">
+          <span class="prompt-card-icon"><i class="ph ph-target"></i></span>
+          <span class="prompt-card-label">Lead monitoring</span>
+        </header>
+        <p class="prompt-card-body"><span class="prompt-caret">&gt;</span>Score new LinkedIn connection requests against the ICP, draft outreach for the top three, and skip the rest.</p>
+      </article>
+      <article class="prompt-card reveal delay-5">
+        <header class="prompt-card-head">
+          <span class="prompt-card-icon"><i class="ph ph-storefront"></i></span>
+          <span class="prompt-card-label">Small-business ops</span>
+        </header>
+        <p class="prompt-card-body"><span class="prompt-caret">&gt;</span>Categorize today&#39;s invoices in the POS as supplies vs. retail, extract shipping line items, and flag any vendor over last month&#39;s average.</p>
+      </article>
     </div>
 
-    <div class="try-mode reveal delay-2">
-      <h3>Autopilot (explicit delegation only)</h3>
-      <p class="autopilot-rule">
-        <strong>NEVER</strong> call <code>run_task</code> unless the user has explicitly said something like &quot;use FSB autopilot&quot;, &quot;delegate this to FSB&quot;, &quot;run the whole task autonomously&quot;, or named <code>run_task</code> directly. Manual mode tools are the default for everything else, including tasks with many steps.
-      </p>
-      <ul class="try-list">
-        <li>
-          <span class="try-tool"><code>run_task</code></span>
-          <span class="try-prompt">&quot;Use FSB autopilot to find the first GitHub repo for <code>fsb-mcp-server</code> and report a one paragraph summary of its README.&quot;</span>
-        </li>
-      </ul>
-    </div>
+    <p class="autopilot-rule reveal">
+      These run as manual-mode tool calls. Autopilot (<code>run_task</code>) only fires when the user explicitly delegates the whole task -- <strong>&quot;use FSB autopilot&quot;</strong>, <strong>&quot;delegate this&quot;</strong>, or names <code>run_task</code> directly. Manual mode is the default for everything else.
+    </p>
   </div>
 </section>
 
@@ -180,7 +190,7 @@
       <h2>Ship a real browser to your agent <span class="text-orange">today</span>.</h2>
       <p>Free, open source, BYO model keys. Works with OpenClaw, Claude, Codex, Cursor, Windsurf, and any MCP host that speaks the OpenAI tool protocol.</p>
       <div class="agents-cta-actions">
-        <a href="https://clawhub.ai/" target="_blank" rel="noopener" class="btn btn-primary">
+        <a href="https://clawhub.ai/lakshmanturlapati/full-selfbrowsing" target="_blank" rel="noopener" class="btn btn-primary">
           Install on ClawHub
         </a>
         <a href="https://github.com/lakshmanturlapati/FSB/tree/main/skills/FSB%20Skill" target="_blank" rel="noopener" class="btn btn-secondary">

--- a/showcase/angular/src/app/pages/agents/agents-page.component.scss
+++ b/showcase/angular/src/app/pages/agents/agents-page.component.scss
@@ -241,87 +241,119 @@
   white-space: pre;
 }
 
-/* --- Try It --- */
-.try-mode {
+/* --- Use-case prompt grid --- */
+.prompt-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
   margin-top: 40px;
-  padding: 28px;
+}
+
+.prompt-card {
+  position: relative;
+  padding: 20px 22px;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   background: var(--bg-card);
+  transition: border-color var(--transition-base), transform var(--transition-base), box-shadow var(--transition-base);
+  overflow: hidden;
 }
 
-.try-mode + .try-mode {
-  margin-top: 24px;
+.prompt-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--accent-color, #ff7a18) 0%, rgba(255, 122, 24, 0) 100%);
+  opacity: 0;
+  transition: opacity var(--transition-base);
 }
 
-.try-mode h3 {
-  margin-bottom: 10px;
-  font-size: 1.15rem;
+.prompt-card:hover {
+  border-color: var(--border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
 }
 
-.try-mode > p {
-  color: var(--text-muted);
-  margin-bottom: 16px;
-  font-size: 0.96rem;
+.prompt-card:hover::before {
+  opacity: 1;
 }
 
-.autopilot-rule {
-  padding: 14px 16px;
-  background: rgba(255, 122, 24, 0.08);
-  border-left: 3px solid var(--accent-color, #ff7a18);
-  border-radius: var(--radius-sm);
-  font-size: 0.95rem !important;
-  line-height: 1.6;
-  color: var(--text-default) !important;
-}
-
-.autopilot-rule strong {
-  color: var(--accent-color, #ff7a18);
-  letter-spacing: 0.04em;
-}
-
-.try-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.prompt-card-head {
   display: flex;
-  flex-direction: column;
+  align-items: center;
   gap: 10px;
+  margin-bottom: 12px;
 }
 
-.try-list li {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
+.prompt-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 122, 24, 0.12);
+  color: var(--accent-color, #ff7a18);
+  font-size: 1.05rem;
+}
+
+.prompt-card-label {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.prompt-card-body {
+  position: relative;
+  margin: 0;
   padding: 12px 14px;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-body);
-}
-
-.try-tool {
-  flex: 0 0 auto;
-  min-width: 110px;
-}
-
-.try-tool code {
-  font-size: 0.88rem;
-  padding: 3px 8px;
-  background: var(--bg-card);
-  border-radius: 4px;
-  color: var(--accent-color, #ff7a18);
-  font-weight: 600;
-}
-
-.try-prompt {
-  flex: 1 1 auto;
-  font-size: 0.94rem;
-  line-height: 1.5;
+  font-size: 0.95rem;
+  line-height: 1.55;
   color: var(--text-default);
 }
 
-.try-prompt code {
-  font-size: 0.88em;
+.prompt-caret {
+  display: inline-block;
+  margin-right: 8px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-weight: 700;
+  color: var(--accent-color, #ff7a18);
+  user-select: none;
+}
+
+.prompt-card-body code {
+  font-size: 0.86em;
+  padding: 1px 5px;
+  background: var(--bg-card);
+  border-radius: 3px;
+}
+
+/* Autopilot footnote (reused from prior try-it section) */
+.autopilot-rule {
+  margin-top: 24px;
+  padding: 14px 18px;
+  background: rgba(255, 122, 24, 0.08);
+  border-left: 3px solid var(--accent-color, #ff7a18);
+  border-radius: var(--radius-sm);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--text-default);
+}
+
+.autopilot-rule strong {
+  color: var(--accent-color, #ff7a18);
+  letter-spacing: 0.02em;
+}
+
+.autopilot-rule code {
+  font-size: 0.86em;
   padding: 1px 5px;
   background: var(--bg-card);
   border-radius: 3px;
@@ -376,8 +408,11 @@
     min-width: 0;
   }
 
-  .try-list li {
-    flex-direction: column;
-    gap: 8px;
+  .prompt-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .prompt-card {
+    padding: 18px;
   }
 }

--- a/skills/FSB Skill/SKILL.md
+++ b/skills/FSB Skill/SKILL.md
@@ -30,11 +30,11 @@ If anything looks off (no page response, unexpected errors, stale state, missing
 
 ## Visual session wrapping
 
-Any external-AI-driven sequence opens with `start_visual_session(client="OpenClaw", ...)` and closes with `end_visual_session(session_token=..., reason=...)`. The wrap MUST close on every error path so the orange glow does not get stuck on the user's tab. Lifecycle details, the try/finally close pattern, and error-path close coverage live in `references/visual-session-lifecycle.md`.
+Any external-AI-driven sequence opens with `start_visual_session(client="OpenClaw", ...)` and closes with `end_visual_session(session_token=..., reason="ended"|"cancelled")`. Those are the only two reason values the MCP schema accepts -- use `ended` for normal completion and `cancelled` for any non-normal termination (error, abort, user cancel). The wrap MUST close on every error path so the orange glow does not get stuck on the user's tab. If `start_visual_session` fails with `NO_OWNED_TAB`, call `open_tab({ url, active: false })` first, then retry. Lifecycle details, the try/finally close pattern, and error-path close coverage live in `references/visual-session-lifecycle.md`.
 
 ## Multi-agent contract
 
-Never pass `agent_id` (the server mints it). Use the `back` tool instead of `execute_js("history.back()")`. Typed errors and recovery rules: see `references/multi-agent-contract.md`.
+Never pass `agent_id` (the server mints it). Use the `back` tool instead of `execute_js("history.back()")`. Each agent owns its own tabs; do not foreground or close tabs you do not own, and do not introduce a global browser lock -- per-agent ownership is the only concurrency mechanism. Typed errors (`NO_OWNED_TAB`, `AMBIGUOUS_TAB`, `TAB_NOT_OWNED`, `AGENT_CAP_REACHED`, `TAB_INCOGNITO_NOT_SUPPORTED`, `TAB_OUT_OF_SCOPE`), the bootstrap recovery ladder, and the default recovery flow: see `references/multi-agent-contract.md`.
 
 ## Vault and credentials
 
@@ -42,8 +42,8 @@ Passwords and CVV resolve INSIDE the extension via `fill_credential` and `use_pa
 
 ## References (load on demand)
 
-- `references/tool-decision-tree.md` -- read_page vs get_dom_snapshot vs get_page_snapshot vs get_site_guide; typed events over .value.
-- `references/multi-agent-contract.md` -- typed errors (TAB_NOT_OWNED, AGENT_CAP_REACHED, TAB_INCOGNITO_NOT_SUPPORTED, TAB_OUT_OF_SCOPE) and the back tool.
+- `references/tool-decision-tree.md` -- read_page vs get_dom_snapshot vs get_page_snapshot vs get_site_guide; when execute_js is first-class vs when typed tools are required; verify after "no detectable effect" warnings.
+- `references/multi-agent-contract.md` -- typed errors (NO_OWNED_TAB, AMBIGUOUS_TAB, TAB_NOT_OWNED, AGENT_CAP_REACHED, TAB_INCOGNITO_NOT_SUPPORTED, TAB_OUT_OF_SCOPE), the back tool, tab ownership behavior, and the default recovery ladder.
 - `references/restricted-tab-recovery.md` -- chrome://, edge://, and web-store recovery tools.
 - `references/vault-boundary.md` -- credential routing rules and forbidden patterns.
 - `references/default-to-fsb.md` -- soft preference and hard escalation rule in full.

--- a/skills/FSB Skill/USAGE.md
+++ b/skills/FSB Skill/USAGE.md
@@ -97,14 +97,15 @@ const { session_token } = await start_visual_session({
 try {
   // FSB tool calls go here. The orange glow is live for the user.
 } finally {
-  await end_visual_session({ session_token, reason: "complete" });
+  await end_visual_session({ session_token, reason: "ended" });
 }
 ```
 
 Cleanup rules (must hold on every termination path, not just success):
 
 - Always close the session in a `finally` block (or equivalent error path handling). The orange glow stays on the user's tab until `end_visual_session` is called. If the agent crashes or returns without closing, the user sees a stuck overlay.
-- `reason` is one of `complete` (normal success), `error` (tool error or exception), `aborted` (agent decided to stop), `user_cancelled` (user interrupted). Pick the one that matches the actual termination state.
+- `reason` is `ended` (normal completion) or `cancelled` (any non-normal termination: error, abort, user cancel, bridge disconnect). The MCP schema accepts only those two values.
+- If `start_visual_session` fails with `NO_OWNED_TAB`, the agent does not own a tab yet. Call `open_tab({ url, active: false })` first, then retry `start_visual_session`.
 - Close exactly once per session. Do NOT call `end_visual_session` twice with the same `session_token`.
 - If `run_task` (autopilot) is being used, autopilot manages its own visual session lifecycle. Do NOT wrap a `run_task` call in your own `start_visual_session` / `end_visual_session`.
 

--- a/skills/FSB Skill/references/multi-agent-contract.md
+++ b/skills/FSB Skill/references/multi-agent-contract.md
@@ -1,6 +1,13 @@
 # FSB multi-agent contract (v0.8.0)
 
-This file documents the rules that make FSB's per-agent tab ownership work. Anyone calling FSB tools through MCP MUST follow these rules; breaking them produces typed errors that recover cleanly only when the caller knows the contract. The contract is small (four error names + the `agent_id` rule + the `back` tool), but every rule matters: bypassing one corrupts the ownership graph and the only recovery is closing the affected tab.
+This file documents the rules that make FSB's per-agent tab ownership work. Anyone calling FSB tools through MCP MUST follow these rules; breaking them produces typed errors that recover cleanly only when the caller knows the contract. The contract is small (six error names + the `agent_id` rule + the `back` tool), but every rule matters: bypassing one corrupts the ownership graph and the only recovery is closing the affected tab.
+
+## Tab ownership behavior (v0.8.0)
+
+- Each agent owns its own tabs. `open_tab` defaults to `active: false` so it claims a tab without stealing the user's focus -- only pass `active: true` when the user explicitly needs to see that tab.
+- Do not foreground a tab unless the task requires it. `switch_tab` defaults to background; it foregrounds only when `active: true` is explicit.
+- Close only tabs this agent owns. `close_tab` refuses the active foreground tab unless `allow_active: true` is set. Never close or reopen Chrome itself.
+- There is no global browser lock. The per-agent ownership graph is the only concurrency mechanism -- do not introduce a global lock as a blocker.
 
 ## Never pass agent_id
 
@@ -13,9 +20,19 @@ Caller-supplied `agent_id` breaks ownership accounting -- a fabricated id either
 [GOOD] click({ selector: "#submit" })
 ```
 
-## Four typed errors and how to recover
+## Six typed errors and how to recover
 
-When an FSB tool call hits one of the dispatcher boundaries, the server returns a structured error with one of the four names below. Match on the name; do not parse the human-readable message.
+When an FSB tool call hits one of the dispatcher boundaries, the server returns a structured error with one of the names below. Match on the name; do not parse the human-readable message.
+
+### NO_OWNED_TAB
+
+- What it means: The calling agent does not currently own any tabs. The most common cause is the very first tool call of a fresh agent session (including `start_visual_session`).
+- What to do: Call `open_tab({ url, active: false })` to claim a tab without stealing focus, then retry the original call. `navigate` and `switch_tab` can also claim an unowned normal tab if one already exists.
+
+### AMBIGUOUS_TAB
+
+- What it means: The calling agent owns multiple tabs and the tool did not specify a `tab_id`, so the target is ambiguous.
+- What to do: Call `list_tabs` to enumerate owned tabs, then retry with the intended `tab_id`.
 
 ### TAB_NOT_OWNED
 
@@ -52,7 +69,16 @@ Note: `go_back` (the existing tool in `mcp/ai/tool-definitions.cjs`) is the same
 
 ## Why the contract matters
 
-FSB's per-agent ownership is what lets multiple AI sessions share one Chrome instance without fighting. The contract is small (four error names plus `agent_id` plus `back`), but every rule matters -- bypassing one rule corrupts the ownership graph and the only recovery is closing the affected tab.
+FSB's per-agent ownership is what lets multiple AI sessions share one Chrome instance without fighting. The contract is small (six error names plus `agent_id` plus `back`), but every rule matters -- bypassing one rule corrupts the ownership graph and the only recovery is closing the affected tab.
+
+## Default recovery ladder
+
+When a tool call fails and you are not sure which layer broke, try these in order before escalating to the doctor:
+
+1. `list_tabs({})` -- check whether this agent owns any tab. Recovery-safe; works on restricted URLs too.
+2. If no owned tab: `open_tab({ url, active: false })` to claim one in the background.
+3. If the tab is on a non-injectable URL (`chrome://`, `edge://`, Web Store, `data:`, `file:`): `navigate({ url })` to a normal `http(s)` page.
+4. If the page loaded but DOM tools still fail: bridge or content-script issue. Run `node scripts/doctor.mjs`.
 
 ## See also
 

--- a/skills/FSB Skill/references/restricted-tab-recovery.md
+++ b/skills/FSB Skill/references/restricted-tab-recovery.md
@@ -1,10 +1,20 @@
 # Restricted-tab recovery
 
-When FSB's active tab is at a restricted URL (`chrome://*`, `edge://*`, `https://chrome.google.com/webstore/*`, `https://chromewebstore.google.com/*`), the FSB content script cannot attach. DOM tools (`read_page`, `get_dom_snapshot`, `click`, `type_text`, etc.) will fail. This file lists the recovery toolset that works even on restricted tabs and shows the standard bootstrap recovery sequence.
+When FSB's active tab is at a restricted URL, the FSB content script cannot attach. DOM tools (`read_page`, `get_dom_snapshot`, `click`, `type_text`, etc.) will fail. The full non-injectable list:
 
-## Why DOM tools fail on chrome:// / edge:// / Web Store
+- `chrome://*`, `edge://*`, `about:*`, `view-source:*`
+- `https://chrome.google.com/webstore/*`, `https://chromewebstore.google.com/*`
+- `data:` URLs (no origin -- the extension cannot register a host match)
+- `file:` URLs (unless the user has manually granted file-URL access to the extension)
+- `blob:` URLs spawned in restricted contexts
 
-Browsers explicitly forbid content scripts from attaching to internal pages and the Chrome Web Store as a security boundary. The Manifest V3 `host_permissions` list cannot match these origins; Chrome rejects them at the policy layer. There is no extension-side workaround -- the boundary is enforced by the browser itself, before any of FSB's code runs.
+This file lists the recovery toolset that works even on these tabs and shows the standard bootstrap recovery sequence.
+
+## Why DOM tools fail on these URLs
+
+Browsers forbid content scripts from attaching to internal pages, the Chrome Web Store, and origin-less schemes (`data:`, `file:`, certain `blob:`) as a security boundary. The Manifest V3 `host_permissions` list cannot match them; Chrome rejects the injection at the policy layer. There is no extension-side workaround -- the boundary is enforced by the browser itself, before any of FSB's code runs.
+
+For local testing, serve the page over `http://localhost` instead of opening a `data:` or `file:` URL.
 
 Without a content script, the FSB extension cannot read the DOM, dispatch typed events, or observe mutations. Any attempt by FSB tools that route through the content script (`read_page`, `click`, `type_text`, `get_dom_snapshot`, etc.) fails fast with an attach error. The recovery path is to leave the restricted tab using a tool that does NOT require content-script attachability.
 

--- a/skills/FSB Skill/references/tool-decision-tree.md
+++ b/skills/FSB Skill/references/tool-decision-tree.md
@@ -13,18 +13,29 @@ Pick the lightest reader that answers the question. Escalate down the list only 
 
 If `get_site_guide` returns a guide, follow the guide's selectors first; only fall back to `read_page` or the snapshot tools when the guide does not cover the current state.
 
-## Typed events over .value
+## execute_js vs typed tools
 
-Always use the typed action tools (`click`, `type_text`, `press_enter`, `press_key`, `select_option`, `check_box`, `hover`, `focus`, `clear_input`, etc.) instead of `execute_js` with `.value =` or `.click()`.
+`execute_js` is a first-class interaction tool in FSB, not a last resort. The current MCP tool description even instructs callers to "try execute_js FIRST" for clicks, scrolls, reads, and attribute lookups, because it bypasses overlay/obscured-element issues, viewport constraints, and CDP timeouts that block native click/scroll.
 
-React, Vue, Solid, and Angular all install change and input handlers that fire only on real user-style events. Setting `input.value = 'foo'` directly via `execute_js` does NOT fire those handlers, so the framework's internal state stays out of sync with the DOM, and the form does not validate, dirty-check, or submit. The same applies to programmatic `.click()` -- it bypasses the synthetic-event pipeline most modern frameworks rely on. The typed tools dispatch real input, change, keydown, keyup, and click events at the DOM level, which the frameworks observe.
+Use this split:
+
+- **Use `execute_js` freely for**: reading DOM (text, attributes, computed styles, hidden nodes), querying multiple elements at once, scrolling, probing structure during exploration, and clicking elements blocked by overlays or off-screen.
+- **Use typed tools (`type_text`, `clear_input`, `select_option`, `check_box`, `press_enter`, `press_key`, `drag`, `drag_drop`) for**: controlled text inputs, validation-sensitive form fields, real drag operations, and any input where framework change handlers must fire.
+- **After any `execute_js` click, verify** with `read_page` or `get_dom_snapshot` -- a true click produces an observable DOM change. If the page state did not change, fall back to the typed `click` tool, which dispatches real CDP events that React/Vue/Angular synthetic-event pipelines listen for.
+
+The one rule that does not bend: `element.value = 'foo'` via `execute_js` will NOT update controlled-input component state in React, Vue, Solid, or Angular. Use `type_text` for any text input bound to framework state.
 
 ```
-[BAD]  execute_js("document.querySelector('input').value = 'foo'")
+[BAD]  execute_js("document.querySelector('input[name=q]').value = 'foo'")
 [GOOD] type_text({ selector: "input[name=q]", text: "foo" })
+
+[OK]   execute_js("return Array.from(document.querySelectorAll('a')).map(a=>a.href)")
+[OK]   execute_js("document.querySelector('#add-to-cart').click(); return true")  // verify after
 ```
 
-Reach for `execute_js` only when the typed tools genuinely cannot express the action (rare; e.g., reading a computed style or invoking a non-DOM API).
+## Verify after a "no detectable effect" warning
+
+`click` (and other action tools) can return a "no detectable effect" warning even when the page actually changed -- the action-detection heuristic produces false negatives on async/animated UIs. Before retrying, verify page state with `read_page` or `get_dom_snapshot`. If the state already advanced, treat the action as successful and continue.
 
 ## Tool-by-tool quick reference
 
@@ -46,7 +57,7 @@ Reach for `execute_js` only when the typed tools genuinely cannot express the ac
 | `go_back` | Step back one history entry. | Use this typed tool, never `execute_js("history.back()")` -- see `references/multi-agent-contract.md`. |
 | `go_forward` | Step forward one history entry. | Pair with `go_back`; same ownership rules. |
 | `refresh` | Reload current tab. | Use after content-script attach failures. |
-| `execute_js` | Last resort for things the typed tools cannot express. | Bypasses framework change handlers; do not use for input or clicks. |
+| `execute_js` | First-class for reads, attribute lookups, scrolls, and clicks blocked by overlays. | Do not use to set `.value` on controlled inputs (use `type_text`); verify state after JS clicks. |
 
 ## Worked example
 

--- a/skills/FSB Skill/references/visual-session-lifecycle.md
+++ b/skills/FSB Skill/references/visual-session-lifecycle.md
@@ -6,18 +6,30 @@ While a visual session is open, the FSB extension paints an orange glow on the a
 
 1. Open the session with `start_visual_session({ client: "OpenClaw", task: <short label> })`. Save the returned `session_token`.
 2. Run the work (any sequence of FSB tools).
-3. Close the session with `end_visual_session({ session_token, reason })` exactly once. The `reason` is one of `complete`, `error`, `aborted`, `user_cancelled`. Use whichever matches the actual termination state.
+3. Close the session with `end_visual_session({ session_token, reason })` exactly once. The `reason` is one of `ended` or `cancelled` (the only values the MCP schema accepts). Use whichever matches the actual termination state.
 
 One open => exactly one close. No exceptions.
 
+## Bootstrap: NO_OWNED_TAB on session open
+
+`start_visual_session` requires the calling agent to already own a tab. On the first call of a new agent session there is no owned tab yet, so the open will fail with `NO_OWNED_TAB`. Recover by opening a tab first, then retrying the visual-session open:
+
+```
+list_tabs({})                                     // optional: see if anything is already owned
+open_tab({ url: "<target>", active: false })      // claim a tab without stealing user focus
+start_visual_session({ client: "OpenClaw", task: "..." })   // now succeeds
+```
+
 ## Termination outcomes (always close)
 
-| Outcome                                          | reason value     |
-|--------------------------------------------------|------------------|
-| Task finished successfully.                      | `complete`       |
-| A typed error fired and the loop cannot recover. | `error`          |
-| The model decided to abort mid-sequence.         | `aborted`        |
-| The user cancelled (stop button, escape, etc.).  | `user_cancelled` |
+The MCP `end_visual_session` schema accepts only two values; map each termination path onto one of them.
+
+| Outcome                                          | reason value |
+|--------------------------------------------------|--------------|
+| Task finished successfully.                      | `ended`      |
+| A typed error fired and the loop cannot recover. | `cancelled`  |
+| The model decided to abort mid-sequence.         | `cancelled`  |
+| The user cancelled (stop button, escape, etc.).  | `cancelled`  |
 
 ## Pattern: try/finally close
 
@@ -25,9 +37,9 @@ One open => exactly one close. No exceptions.
 const { session_token } = await start_visual_session({ client: "OpenClaw", task: "<short label>" });
 try {
   // ... FSB tool calls ...
-  await end_visual_session({ session_token, reason: "complete" });
+  await end_visual_session({ session_token, reason: "ended" });
 } catch (err) {
-  await end_visual_session({ session_token, reason: "error" });
+  await end_visual_session({ session_token, reason: "cancelled" });
   throw err;
 }
 ```
@@ -36,11 +48,11 @@ Even when the model is reasoning across multiple turns, the close MUST run on ev
 
 ## Error-path close coverage
 
-- Typed multi-agent error (`TAB_NOT_OWNED`, `AGENT_CAP_REACHED`, `TAB_INCOGNITO_NOT_SUPPORTED`, `TAB_OUT_OF_SCOPE`) -- close with `reason: "error"` and report the typed error to the user.
-- Restricted-tab attach failure (`chrome://`, `edge://`, Web Store) -- recover via `references/restricted-tab-recovery.md` first; only close if recovery itself fails.
-- User cancel mid-task -- close with `reason: "user_cancelled"`.
-- Model self-aborts (decides task is impossible) -- close with `reason: "aborted"`.
-- Network / bridge disconnect -- close with `reason: "error"`. The bridge may have already invalidated the session; the close call is idempotent and safe to attempt anyway.
+- Typed multi-agent error (`TAB_NOT_OWNED`, `AGENT_CAP_REACHED`, `TAB_INCOGNITO_NOT_SUPPORTED`, `TAB_OUT_OF_SCOPE`, `NO_OWNED_TAB`, `AMBIGUOUS_TAB`) -- close with `reason: "cancelled"` and report the typed error.
+- Restricted-tab attach failure (`chrome://`, `edge://`, Web Store, `data:`, `file:`) -- recover via `references/restricted-tab-recovery.md` first; only close if recovery itself fails.
+- User cancel mid-task -- close with `reason: "cancelled"`.
+- Model self-aborts (decides task is impossible) -- close with `reason: "cancelled"`.
+- Network / bridge disconnect -- close with `reason: "cancelled"`. The bridge may have already invalidated the session; the close call is idempotent and safe to attempt anyway.
 
 ## Anti-patterns
 
@@ -53,8 +65,8 @@ Even when the model is reasoning across multiple turns, the close MUST run on ev
 ```
 
 ```
-[BAD]  end_visual_session({ session_token })   // missing reason
-[GOOD] end_visual_session({ session_token, reason: "complete" })
+[BAD]  end_visual_session({ session_token, reason: "complete" })   // schema rejects this
+[GOOD] end_visual_session({ session_token, reason: "ended" })      // or "cancelled"
 ```
 
 ## See also


### PR DESCRIPTION
## Summary

- **Skill (docs):** align the FSB OpenClaw skill with the actual FSB 0.8.0 MCP runtime, based on a test-drive against the live tool surface.
- **Showcase (/agents):** ground the use-case section in real recurring workflows, modernize the prompt grid, tighten the power-cards, and deep-link to the ClawHub listing.

## Skill changes — what was off

| Issue | Was | Now |
|---|---|---|
| `end_visual_session` reason values | `complete` / `error` / `aborted` / `user_cancelled` (rejected by `z.enum(['cancelled','ended'])`) | `ended` / `cancelled` |
| `NO_OWNED_TAB` on first call | undocumented | bootstrap recovery: `open_tab({ url, active:false })` then retry |
| `execute_js` positioning | "last resort" | first-class for reads, scrolls, probing, overlay-blocked clicks (matches actual tool description); typed tools required for controlled inputs / drag / validation |
| Typed errors | 4 documented (`TAB_NOT_OWNED`, `AGENT_CAP_REACHED`, `TAB_INCOGNITO_NOT_SUPPORTED`, `TAB_OUT_OF_SCOPE`) | 6 documented (adds `NO_OWNED_TAB`, `AMBIGUOUS_TAB`) |
| Non-injectable URLs | `chrome://` / `edge://` / Web Store | also `data:`, `file:`, `blob:`, `about:`, `view-source:` |
| "No detectable effect" warning | not addressed | new rule: verify state before retrying — action tools can false-negative on async UIs |
| Tab ownership behavior | implicit | explicit notes: no foregrounding by default, no global browser lock, close only owned tabs |

Files: `skills/FSB Skill/SKILL.md`, `USAGE.md`, `references/visual-session-lifecycle.md`, `references/tool-decision-tree.md`, `references/multi-agent-contract.md`, `references/restricted-tab-recovery.md`.

## Showcase changes (/agents)

- Replace generic `example.com` / `duckduckgo.com` prompts with five grounded use cases (inbox triage, support replies, logged-in dashboards, lead monitoring, small-business ops).
- New `.prompt-grid` / `.prompt-card` styles: terminal-style prompt blocks with a Phosphor icon, monospace uppercase eyebrow label, and an orange `>` caret. Hover lift + fading orange edge gradient. Two columns on desktop, one on mobile.
- Tighten the four "Why FSB MCP is powerful" cards — shorter, terser bodies; same stats / headings; `<code>` accents preserved.
- Update both "Install on ClawHub" buttons (hero + CTA) to `https://clawhub.ai/lakshmanturlapati/full-selfbrowsing`.
- Footnote (manual-mode vs autopilot) restyled with the existing `.autopilot-rule` callout.

Tokens reused: `--accent-color`, `--border-color`, `--border-hover`, `--bg-card`, `--bg-body`, `--radius-md`, `--radius-sm`, `--shadow-sm`, `--transition-base`, `--font-mono`. No new design primitives.

## Test plan

- [ ] Visit `/agents` — confirm new prompt-card grid renders with icons + caret + hover gradient, and collapses to one column on mobile.
- [ ] Confirm the four power-cards still show their stats (`50+`, `N agents`, `0 leaks`, `Live`) with terser bodies.
- [ ] Click both "Install on ClawHub" buttons — both should open `https://clawhub.ai/lakshmanturlapati/full-selfbrowsing`.
- [ ] Spot-check the skill markdown renders cleanly (frontmatter intact, no broken anchors).
- [ ] Optional: from an OpenClaw session, call `start_visual_session` followed by `end_visual_session({ reason: "ended" })` and confirm the schema accepts it.