### PR TITLE
docs(skill): ClawHub review fixes + frontmatter v0.9.62 bump

### DIFF
--- a/skills/FSB Skill/SKILL.md
+++ b/skills/FSB Skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: FSB
 description: FSB drives the user's Chrome via the FSB extension and an MCP bridge for live web tasks.
-version: 0.9.61
+version: 0.9.62
 user-invocable: true
 requires:
   bins: [node, npx]
@@ -23,6 +23,10 @@ FSB lets you drive the user's real Chrome via the FSB extension and a local MCP 
 - ALWAYS escalate to FSB when the page is dynamic, gated, or rendered after JS.
 - Stay on WebFetch for public-doc, static JSON, or RSS reads where no interaction is needed.
 - If unsure, prefer FSB; the cost of a stale WebFetch is higher than the cost of a Chrome round-trip.
+
+## Sensitive actions and logged-in context
+
+FSB drives the user's real Chrome, so every action runs inside whatever sessions, cookies, and saved auth that browser already holds. Before the final click that submits a purchase, payment, account change (password update, data deletion, permission grant, settings write), or public post (tweet, comment, DM, issue, PR), pause and ask the user to confirm in chat -- state the action, the target site, and any amount or recipient, then wait for an explicit yes. Vault-backed fills (`fill_credential`, `use_payment_method`) are allowed during preparation; only the final submission is gated. Read-only inspection (`read_page`, `get_dom_snapshot`, `get_text`) does not require confirmation.
 
 ## Doctor-first protocol
 

--- a/skills/FSB Skill/USAGE.md
+++ b/skills/FSB Skill/USAGE.md
@@ -51,7 +51,8 @@ The goal of this page: get a new user from a clean machine to a green doctor in 
    ```
 
    Notes:
-   - `npx -y fsb-mcp-server` invocations stay unpinned by design; this matches existing FSB convention so users always pull the latest published bridge.
+   - What these commands do: each invocation spawns the `fsb-mcp-server` Node package via npx. `install --list` only prints detected MCP hosts and exits. `install --<host>` writes the FSB stdio block into that host's MCP config file and nothing else. Run only the host installers you actually want configured; decline prompts otherwise.
+   - By default, `npx -y fsb-mcp-server` resolves to the latest published bridge so security fixes ship without re-running the installer. If you prefer review-before-upgrade, pin a release by replacing `fsb-mcp-server` with `fsb-mcp-server@x.y.z` (see releases at `https://www.npmjs.com/package/fsb-mcp-server`) in the stdio block printed by `node scripts/print-stdio.mjs` and in any host-specific install command. The bridge accepts the same arguments either way.
    - Zero environment variables are needed. Vault values (passwords, payment methods) resolve inside the FSB Chrome extension's encrypted storage and never cross into the MCP server process or the OpenClaw host process. See `references/vault-boundary.md` for the boundary rules.
 
 3. **Verify with the doctor.**

--- a/tests/skill-fsb-spec.test.js
+++ b/tests/skill-fsb-spec.test.js
@@ -60,7 +60,7 @@ const nameMatch = fm.match(/^name:\s*(\S.*?)\s*$/m);
 check(nameMatch && nameMatch[1] === 'FSB', 'frontmatter name === FSB');
 
 const versionMatch = fm.match(/^version:\s*(\S+)\s*$/m);
-check(versionMatch && versionMatch[1] === '0.9.61', 'frontmatter version === 0.9.61');
+check(versionMatch && versionMatch[1] === '0.9.62', 'frontmatter version === 0.9.62');
 
 // requires.bins must include node and npx
 const binsMatch = fm.match(/bins:\s*\[([^\]]*)\]/);


### PR DESCRIPTION
## Summary

Skill-only maintenance after the v0.9.62 milestone shipped. **No extension, MCP server, or install-script behavior changes** — only `skills/FSB Skill/` prose + one matching test assertion.

### ClawHub review findings (text-only fixes)

- **ASI02 + ASI03** — `SKILL.md` gains a new "Sensitive actions and logged-in context" section instructing the model to pause for explicit user confirmation before submitting purchases, payments, account changes, or public posts. Vault-backed fills (`fill_credential`, `use_payment_method`) are still allowed during preparation; only the final submission is gated. Read-only inspection unchanged.
- **ASI04** — `USAGE.md` "unpinned by design" line replaced with a tradeoff acknowledgement plus a pinning recipe (`fsb-mcp-server@x.y.z`). Default `npx -y fsb-mcp-server` command unchanged.
- **ASI05** — `USAGE.md` adds a disclosure note describing what `install --list` and `install --<host>` actually do (transparency for the spawn-in-`install-host.mjs` path).

### Freshness

- `SKILL.md` frontmatter `version: 0.9.61` -> `version: 0.9.62`. The project-wide v0.9.62 bump in `2ceb9e5` updated `extension/manifest.json` and `package.json` but missed the skill frontmatter.
- `tests/skill-fsb-spec.test.js` line 63: updated hardcoded version assertion to track the bump.

### What is NOT touched

- `metadata.openclaw.install` block in SKILL.md frontmatter (OpenClaw install path is byte-identical).
- All three skill scripts (`doctor.mjs`, `print-stdio.mjs`, `install-host.mjs`).
- All seven reference files under `skills/FSB Skill/references/`.
- Any code in `mcp/`, `extension/`, `showcase/`, or `tests/` other than the one version assertion.

## Test plan

- [x] `node tests/skill-fsb-spec.test.js` -> 48/48 pass
- [x] `git diff` confirms only 3 files touched (+8 / -3 lines)
- [x] Earlier audit verified all other skill claims still match v0.9.62 contract (tool counts, typed errors, doctor layers, badge allowlist, references, scripts) -- no further drift after the 89-commit fast-forward
- [ ] Re-submit to ClawHub for updated security verdict