### PR TITLE
showcase: SEO/GEO refinements + zero-visual-change perf wins

### DIFF
--- a/showcase/angular/package-lock.json
+++ b/showcase/angular/package-lock.json
@@ -874,16 +874,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@angular/build/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.19.0"
-      }
-    },
     "node_modules/@angular/build/node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
@@ -896,13 +886,6 @@
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0"
       }
-    },
-    "node_modules/@angular/build/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "extraneous": true,
-      "license": "MIT"
     },
     "node_modules/@angular/build/node_modules/vite": {
       "version": "7.3.2",

--- a/showcase/angular/prerender-routes.txt
+++ b/showcase/angular/prerender-routes.txt
@@ -1,4 +1,5 @@
 /
 /about
+/agents
 /privacy
 /support

--- a/showcase/angular/public/llms.txt
+++ b/showcase/angular/public/llms.txt
@@ -6,6 +6,18 @@ FSB also works as an MCP browser layer for AI agents. Claude Code, Codex, Cursor
 
 OpenClaw users get a dedicated FSB skill at `skills/FSB Skill/` in the FSB repo. The skill is the canonical OpenClaw onboarding path: it runs the doctor flow against `fsb-mcp-server`, prints the OpenClaw stdio config block for the user to paste, and offers consent-gated install for any other detected MCP hosts.
 
+## How FSB compares
+
+Unlike cloud browser agents that run in a headless container without your cookies, FSB is local-first: it drives the user's real Chrome session, uses keys stored encrypted in Chrome local storage (BYO API key, never relayed through a vendor backend), and inherits any logged-in state, MFA, and saved extensions already on the machine.
+
+## Use cases
+
+- Inbox triage: open Gmail, label billing threads, draft replies in the user's tone, flag urgent items.
+- Support replies: in Zendesk, draft answers to open tickets about pricing, order status, and shipping using the help center as ground truth.
+- Logged-in dashboards: pull yesterday's revenue, signups, and refund count from analytics dashboards and post a one-paragraph summary.
+- Lead monitoring: score new LinkedIn connection requests against an ICP, draft outreach for the top three, skip the rest.
+- Small-business ops: categorize today's POS invoices as supplies vs. retail, extract shipping line items, and flag any vendor over last month's average.
+
 ## Docs
 
 - [About](https://full-selfbrowsing.com/about): Watch FSB drive Google, search Amazon, and book travel autonomously.

--- a/showcase/angular/public/sitemap.xml
+++ b/showcase/angular/public/sitemap.xml
@@ -3,21 +3,31 @@
   <url>
     <loc>https://full-selfbrowsing.com</loc>
     <lastmod>2026-05-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/about</loc>
     <lastmod>2026-05-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/agents</loc>
     <lastmod>2026-05-12</lastmod>
-  </url>
-  <url>
-    <loc>https://full-selfbrowsing.com/privacy</loc>
-    <lastmod>2026-05-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/support</loc>
     <lastmod>2026-05-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://full-selfbrowsing.com/privacy</loc>
+    <lastmod>2026-05-12</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/showcase/angular/scripts/build-crawler-files.mjs
+++ b/showcase/angular/scripts/build-crawler-files.mjs
@@ -17,7 +17,15 @@ const PUBLIC_DIR = join(ANGULAR_ROOT, 'public');
 const SCRIPTS_DIR = __dirname;
 
 const HOST = 'https://full-selfbrowsing.com';
-const ROUTES = ['/', '/about', '/agents', '/privacy', '/support']; // PRE-03 locked, /dashboard excluded
+// PRE-03 locked, /dashboard excluded. changefreq/priority hint relative importance
+// to crawlers; lastmod is regenerated per build (see generateSitemap).
+const ROUTES = [
+  { path: '/',        changefreq: 'weekly',  priority: '1.0' },
+  { path: '/about',   changefreq: 'weekly',  priority: '0.9' },
+  { path: '/agents',  changefreq: 'weekly',  priority: '0.9' },
+  { path: '/support', changefreq: 'monthly', priority: '0.7' },
+  { path: '/privacy', changefreq: 'yearly',  priority: '0.5' },
+];
 const MAX_LLMS_FULL_BYTES = 256000;
 
 function todayIsoDate() {
@@ -35,10 +43,12 @@ function generateSitemap() {
   lines.push('<?xml version="1.0" encoding="UTF-8"?>');
   lines.push('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
   for (const route of ROUTES) {
-    const loc = route === '/' ? HOST : `${HOST}${route}`;
+    const loc = route.path === '/' ? HOST : `${HOST}${route.path}`;
     lines.push('  <url>');
     lines.push(`    <loc>${loc}</loc>`);
     lines.push(`    <lastmod>${lastmod}</lastmod>`);
+    lines.push(`    <changefreq>${route.changefreq}</changefreq>`);
+    lines.push(`    <priority>${route.priority}</priority>`);
     lines.push('  </url>');
   }
   lines.push('</urlset>');

--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
@@ -1,7 +1,7 @@
 <nav class="nav" [class.scrolled]="navScrolled">
   <div class="nav-inner">
     <a routerLink="/" class="nav-brand" (click)="closeMobileMenu()">
-      <img src="assets/icon128.png" alt="FSB Logo">
+      <img src="assets/icon128.png" alt="FSB Logo" width="32" height="32" decoding="async">
       <span>FSB</span>
     </a>
     <div class="nav-links">
@@ -42,7 +42,7 @@
   <div class="container">
     <div class="footer-inner">
       <div class="footer-brand">
-        <img src="assets/icon48.png" alt="FSB">
+        <img src="assets/icon48.png" alt="FSB" width="28" height="28" loading="lazy" decoding="async">
         <span>FSB</span>
       </div>
       <div class="footer-links">

--- a/showcase/angular/src/app/pages/agents/agents-page.component.html
+++ b/showcase/angular/src/app/pages/agents/agents-page.component.html
@@ -2,7 +2,7 @@
 <section class="agents-hero">
   <div class="container">
     <div class="agents-hero-badge reveal">
-      <img src="assets/providers/openclaw.svg" alt="OpenClaw" class="agents-hero-mark">
+      <img src="assets/providers/openclaw.svg" alt="OpenClaw" class="agents-hero-mark" width="22" height="22" decoding="async">
       <span>OpenClaw Ready</span>
     </div>
     <h1 class="reveal delay-1">

--- a/showcase/angular/src/app/pages/agents/agents-page.component.ts
+++ b/showcase/angular/src/app/pages/agents/agents-page.component.ts
@@ -24,6 +24,7 @@ export class AgentsPageComponent implements OnInit {
     const d = 'Drive your real Chrome from OpenClaw, Claude, Codex, Cursor, and more. Install the FSB OpenClaw skill in 3 steps and use 50+ MCP tools to act, observe, verify.';
     this.applyMeta(t, d, url);
     this.injectAgentsPageJsonLd();
+    this.injectInstallHowToJsonLd();
   }
 
   private applyMeta(t: string, d: string, url: string): void {
@@ -77,6 +78,48 @@ export class AgentsPageComponent implements OnInit {
     const script = this.renderer.createElement('script') as HTMLScriptElement;
     this.renderer.setAttribute(script, 'type', 'application/ld+json');
     this.renderer.setAttribute(script, 'data-ld', 'agents-page');
+    const text = this.renderer.createText(json);
+    this.renderer.appendChild(script, text);
+    this.renderer.appendChild(this.doc.head, script);
+  }
+
+  private injectInstallHowToJsonLd(): void {
+    if (this.doc.head.querySelector('script[data-ld="agents-howto"]')) {
+      return;
+    }
+    const payload = {
+      '@context': 'https://schema.org',
+      '@type': 'HowTo',
+      '@id': `${HOST}/agents#install-howto`,
+      name: 'Install FSB for OpenClaw and MCP clients',
+      description: 'Three-step install: Chrome extension, FSB MCP server config, doctor verification.',
+      totalTime: 'PT5M',
+      url: `${HOST}/agents`,
+      step: [
+        {
+          '@type': 'HowToStep',
+          position: 1,
+          name: 'Install the FSB Chrome extension',
+          text: 'Primary path: paste the Chrome Web Store URL into Chrome\u2019s address bar (chromewebstore.google.com/detail/badgafnfchcihdfnjneklogedcdkmjfk). Fallback: download the latest .zip from GitHub Releases and load unpacked at chrome://extensions with Developer mode on.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 2,
+          name: 'Install the FSB MCP server config',
+          text: 'Print the canonical OpenClaw stdio block with `node scripts/print-stdio.mjs` and paste it into your MCP host config. Or use the FSB CLI: `npx -y fsb-mcp-server install --list` to discover supported hosts, then `npx -y fsb-mcp-server install --claude-desktop` (or your host).',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 3,
+          name: 'Verify with the doctor',
+          text: 'Run the six-layer diagnostic: `node scripts/doctor.mjs`. Expect [OK] on every layer. If any layer fails, the doctor prints a one-line next step; the full recovery table is in USAGE.md inside the skill.',
+        },
+      ],
+    };
+    const json = JSON.stringify(payload).replace(/</g, '\\u003c');
+    const script = this.renderer.createElement('script') as HTMLScriptElement;
+    this.renderer.setAttribute(script, 'type', 'application/ld+json');
+    this.renderer.setAttribute(script, 'data-ld', 'agents-howto');
     const text = this.renderer.createText(json);
     this.renderer.appendChild(script, text);
     this.renderer.appendChild(this.doc.head, script);

--- a/showcase/angular/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/showcase/angular/src/app/pages/dashboard/dashboard-page.component.ts
@@ -1,7 +1,7 @@
-import { AfterViewInit, Component, ElementRef, NgZone, OnDestroy, OnInit, inject } from '@angular/core';
+import { AfterViewInit, Component, DOCUMENT, ElementRef, NgZone, OnDestroy, OnInit, Renderer2, inject } from '@angular/core';
 import { Meta } from '@angular/platform-browser';
 
-/* Global CDN libraries loaded via script tags in index.html */
+/* CDN libraries loaded lazily on /dashboard only (see loadDashboardCdnScripts). */
 declare const Html5Qrcode: any;
 declare const LZString: any;
 
@@ -81,9 +81,27 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly zone = inject(NgZone);
   private readonly meta = inject(Meta);
+  private readonly renderer = inject(Renderer2);
+  private readonly doc = inject(DOCUMENT);
 
   ngOnInit(): void {
     this.meta.updateTag({ name: 'robots', content: 'noindex, nofollow' });
+    this.loadDashboardCdnScripts();
+  }
+
+  private loadDashboardCdnScripts(): void {
+    const libs: ReadonlyArray<readonly [string, string]> = [
+      ['dash-html5-qrcode', 'https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js'],
+      ['dash-lz-string',    'https://unpkg.com/lz-string@1.5.0/libs/lz-string.min.js'],
+    ];
+    for (const [id, src] of libs) {
+      if (this.doc.head.querySelector(`script[data-cdn="${id}"]`)) continue;
+      const s = this.renderer.createElement('script') as HTMLScriptElement;
+      this.renderer.setAttribute(s, 'src', src);
+      this.renderer.setAttribute(s, 'data-cdn', id);
+      this.renderer.setAttribute(s, 'defer', '');
+      this.renderer.appendChild(this.doc.body, s);
+    }
   }
 
   // ---- Constants ----

--- a/showcase/angular/src/app/pages/home/home-page.component.html
+++ b/showcase/angular/src/app/pages/home/home-page.component.html
@@ -87,14 +87,14 @@
     <div class="competitors-row reveal">
       <div class="competitor-card">
         <div class="competitor-logo">
-          <img src="/assets/providers/google.png" alt="Google">
+          <img src="/assets/providers/google.png" alt="Google" width="36" height="36" loading="lazy" decoding="async">
         </div>
         <h4>Project Mariner</h4>
         <span class="competitor-tag"><i class="fa-solid fa-eye"></i> Vision</span>
       </div>
       <div class="competitor-card">
         <div class="competitor-logo">
-          <img src="/assets/providers/anthropic.webp" alt="Anthropic">
+          <img src="/assets/providers/anthropic.webp" alt="Anthropic" width="36" height="36" loading="lazy" decoding="async">
         </div>
         <h4>Computer Use</h4>
         <span class="competitor-tag"><i class="fa-solid fa-eye"></i> Vision</span>
@@ -108,7 +108,7 @@
       </div>
       <div class="competitor-card">
         <div class="competitor-logo">
-          <img src="/assets/providers/openclaw.svg" alt="OpenClaw">
+          <img src="/assets/providers/openclaw.svg" alt="OpenClaw" width="36" height="36" loading="lazy" decoding="async">
         </div>
         <h4>OpenClaw</h4>
         <span class="competitor-tag"><i class="fa-solid fa-eye"></i> Vision</span>
@@ -117,7 +117,7 @@
 
     <div class="fsb-highlight-card reveal">
       <div class="fsb-highlight-header">
-        <img src="/assets/icon48.png" alt="FSB">
+        <img src="/assets/icon48.png" alt="FSB" width="36" height="36" loading="lazy" decoding="async">
         <h3>FSB</h3>
         <span class="fsb-tag"><i class="fa-solid fa-code"></i> DOM-Based</span>
       </div>
@@ -202,7 +202,7 @@
       <div class="provider-card recommended reveal delay-1">
         <span class="provider-badge">Recommended</span>
         <div class="provider-icon">
-          <img src="/assets/providers/xai.png" alt="xAI">
+          <img src="/assets/providers/xai.png" alt="xAI" width="40" height="40" loading="lazy" decoding="async">
         </div>
         <h3>xAI Grok</h3>
         <p class="provider-models">Grok 4.1, Grok 4.1 Fast, Grok Code Fast</p>
@@ -216,21 +216,21 @@
       </div>
       <div class="provider-card reveal delay-3">
         <div class="provider-icon">
-          <img src="/assets/providers/anthropic.webp" alt="Anthropic">
+          <img src="/assets/providers/anthropic.webp" alt="Anthropic" width="40" height="40" loading="lazy" decoding="async">
         </div>
         <h3>Anthropic</h3>
         <p class="provider-models">Claude Sonnet 4.5, Haiku 4.5, Opus 4.1</p>
       </div>
       <div class="provider-card reveal delay-4">
         <div class="provider-icon">
-          <img src="/assets/providers/google.png" alt="Google Gemini">
+          <img src="/assets/providers/google.png" alt="Google Gemini" width="40" height="40" loading="lazy" decoding="async">
         </div>
         <h3>Google Gemini</h3>
         <p class="provider-models">2.5 Flash, 2.5 Pro, 2.0 Flash (FREE)</p>
       </div>
       <div class="provider-card reveal delay-5">
         <div class="provider-icon">
-          <img src="/assets/providers/openrouter.svg" alt="OpenRouter">
+          <img src="/assets/providers/openrouter.svg" alt="OpenRouter" width="40" height="40" loading="lazy" decoding="async">
         </div>
         <h3>OpenRouter</h3>
         <p class="provider-models">200+ models through a single API key</p>

--- a/showcase/angular/src/index.html
+++ b/showcase/angular/src/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>FSB</title>
+  <meta name="description" content="FSB (Full Self-Browsing) is an open-source Chrome extension that automates the browser via natural language. Multi-model AI, 50+ browser actions, MCP-compatible for Claude Code, Codex, Cursor, and OpenClaw.">
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Prerender-safe theme bootstrap: guard requires `typeof localStorage !== 'undefined'` (PITFALLS.md P1, D-20) -->

--- a/showcase/angular/src/index.html
+++ b/showcase/angular/src/index.html
@@ -23,9 +23,9 @@
 </head>
 <body>
   <app-root></app-root>
-  <!-- CDN libraries for dashboard: QR code scanning and LZ-string decompression -->
-  <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
-  <script src="https://unpkg.com/lz-string@1.5.0/libs/lz-string.min.js"></script>
+  <!-- Dashboard CDN libraries (html5-qrcode + lz-string) load lazily on /dashboard
+       via DashboardPageComponent.loadDashboardCdnScripts() — they were previously
+       global, costing ~105 KB unused JS on every non-dashboard route. -->
   <!-- Dashboard runtime state helpers (preview surface, remote control, task recovery derivation) -->
   <script src="assets/dashboard-runtime-state.js"></script>
 </body>

--- a/showcase/angular/src/styles.scss
+++ b/showcase/angular/src/styles.scss
@@ -1,6 +1,26 @@
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css');
 @import url('https://unpkg.com/@phosphor-icons/web@2.1.1/src/regular/style.css');
 
+/* PERF: font-display swap overrides. CDN icon CSS omits font-display, leaving browsers in the
+   default "block" period (300 ms invisible-icon flash). These declarations merge with the
+   upstream @font-face by font-family name and only update font-display. */
+@font-face { font-family: 'Font Awesome 6 Free';   font-display: swap; }
+@font-face { font-family: 'Font Awesome 6 Brands'; font-display: swap; }
+@font-face { font-family: 'Phosphor';              font-display: swap; }
+
+/* PERF: CLS mitigation. Reserve 1em inline slot for icon-font glyphs so late icon-stylesheet
+   load does not shift surrounding inline content. Icons already render at 1em width once their
+   font loads; this just claims the slot earlier. Steady-state visual is identical. */
+i[class^="ph "], i[class*=" ph "],
+i.fa-solid, i.fa-regular, i.fa-brands, i[class^="fa-"], i[class*=" fa-"] {
+  display: inline-block;
+  width: 1em;
+  min-width: 1em;
+  line-height: 1;
+  text-align: center;
+  font-style: normal;
+}
+
 /* Shared showcase foundation: tokens, reset, typography, and utilities only. */
 :root {
   --primary: #ff6b35;


### PR DESCRIPTION
## Summary

Two commits hardening the public showcase site (`full-selfbrowsing.com`):

- **`12dd20d` chore(showcase): SEO/GEO refinements** — fix `/agents` prerender bug, add HowTo JSON-LD, enrich sitemap, add fallback meta description, sharpen `llms.txt`.
- **`8ee731d` perf(showcase): zero-visual-change CLS and unused-JS wins** — move dashboard CDN scripts off global, reserve 1em icon-glyph slot, font-display swap, width/height + lazy on 11 imgs.

OG image dimensions intentionally untouched (kept at 1000x1000).

### SEO/GEO highlights

| Fix | What it does |
|---|---|
| Prerender `/agents` | Was listed in sitemap + had full meta, but missing from `prerender-routes.txt` — JS-disabled crawlers and most GEO bots saw an empty shell. |
| HowTo JSON-LD on `/agents` | Mirrors existing JSON-LD injector pattern (Renderer2, data-ld idempotency, T-LD-01 `<` escape). Strong GEO signal for "how do I install" queries. |
| Sitemap changefreq + priority | Per-route values (`/` 1.0 weekly, `/about` 0.9 weekly, `/agents` 0.9 weekly, `/support` 0.7 monthly, `/privacy` 0.5 yearly). Single source of truth in `build-crawler-files.mjs`. |
| Fallback `<meta name="description">` | `index.html` had none — any prerender race shipped descriptionless. Per-page components still override via `Meta.updateTag`. |
| `llms.txt` sharpening | Comparison-framing line + use-case bullets lifted from `llms-full.source.md`. |

### Performance highlights

Lighthouse on production reported **Performance 77** with **CLS 0.675** (budget 0.1). FCP/LCP/SI all clock at 0.4s — load time is fine, layout shift is the score drag. Root cause: icon-font glyphs (`<i class="ph …">`, `<i class="fa-…">`) render width-0 before the CDN-imported icon stylesheets parse, then jump to 1em — every icon shifts inline content.

| Fix | Impact |
|---|---|
| Move `unpkg.com/html5-qrcode` + `lz-string` (~105 KB) off global `index.html` | Removed from 5 of 6 routes; loaded lazily in `DashboardPageComponent.ngOnInit` |
| Reserve `width: 1em; min-width: 1em` on icon glyphs | Primary CLS mitigation; pre-claims slot before icon CSS parses |
| `font-display: swap` overrides on Font Awesome + Phosphor `@font-face` | Cuts the 300ms invisible-icon flash |
| `width`/`height` + `loading="lazy"` `decoding="async"` on all 11 `<img>` | CLS hardening + image lazyload |

Font Awesome / Phosphor self-hosting (the larger ~135KB unused-CSS win) is intentionally deferred — measure these wins first before paying the dependency-graph tax.

## Test plan

- [x] `npm run build` — clean prerender of all 5 routes, no warnings
- [x] `BASE_URL=http://localhost:4250 node scripts/smoke-crawler.mjs` — **48/48 assertions pass** against local dist
- [x] JSON-LD validity: home (Organization+SoftwareApplication), agents (SoftwareApplication+HowTo), about (VideoObject), support (FAQPage) — all parse, all preserve `\u003c` escape (T-LD-01)
- [x] Sitemap regenerated by `prebuild` with `<changefreq>`/`<priority>` on all 5 routes
- [x] Canonical link present on all 5 prerendered routes
- [x] Exactly 1 `<meta name="description">` per route (fallback + per-page override merge correctly via `Meta.updateTag`)
- [x] Icon-slot reservation rule (`i[class^="ph "]…{width:1em;…}`) confirmed in bundled CSS
- [x] `font-display:swap` appears 3x in styles bundle
- [x] All 11 `<img>` tags carry `width`/`height` in prerendered output
- [ ] Visual diff vs production (manual; do once Vercel preview is up)
- [ ] Re-run Lighthouse on Vercel preview — expect CLS < 0.1, Performance 88+