### PR TITLE
fix(showcase): restore package-lock.json (deploy fix)

### DIFF
--- a/showcase/angular/package-lock.json
+++ b/showcase/angular/package-lock.json
@@ -874,6 +874,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@angular/build/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@angular/build/node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
@@ -886,6 +896,13 @@
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@angular/build/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/@angular/build/node_modules/vite": {
       "version": "7.3.2",


### PR DESCRIPTION
## Summary

PR #35 inadvertently committed a `package-lock.json` diff that broke the post-merge Fly deploy. Restoring the lockfile to its v0.9.62 state (commit `2ceb9e5`) so `npm ci` is clean again.

### Root cause

A local `npm install` during PR #35's work removed two lockfile entries marked `extraneous: true`:
- `@angular/build/node_modules/@types/node@25.6.0`
- `@angular/build/node_modules/undici-types@7.19.2`

The diff looked harmless (only removals, no additions), so it got staged. But Fly's strict `npm ci` then errored:

\`\`\`
npm error Missing: @types/node@25.7.0 from lock file
npm error Missing: undici-types@7.21.0 from lock file
\`\`\`

Those entries are still referenced by the resolved dependency tree, so removing them put the lockfile out of sync with package.json.

This is a recurrence of the same class of bug as PR #15 (commit `c00fb8d` — "fix(221): regenerate showcase/angular/package-lock.json (deploy fix)").

## Test plan

- [x] Local `npm ci` succeeds against restored lockfile (with no node_modules pre-existing)
- [x] Local `npm run build` produces all 5 prerendered routes
- [ ] CI passes (extension, mcp, showcase build+crawler smoke, all-green)
- [ ] Fly deploy succeeds post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)