### PR TITLE
chore(showcase): security headers + ship dashboard-runtime-state.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ WORKDIR /build
 COPY showcase/angular/package.json showcase/angular/package-lock.json ./
 RUN npm ci
 
-# Copy Angular source and assets (angular.json references ../assets)
+# Copy Angular source and assets (angular.json references ../assets and ../js)
 COPY showcase/angular/ ./
 COPY showcase/assets/ ../assets/
+COPY showcase/js/ ../js/
 RUN npx ng build --configuration production
 
 # ---

--- a/showcase/server/server.js
+++ b/showcase/server/server.js
@@ -29,6 +29,42 @@ const queries = new Queries(db);
 // Express app
 const app = express();
 
+// Drop the default x-powered-by: Express header (information disclosure).
+app.disable('x-powered-by');
+
+// Security headers (Lighthouse Best Practices: HSTS, COOP, XFO, CSP, etc.).
+// CSP keeps 'unsafe-inline' for scripts/styles because the showcase ships
+// inline JSON-LD scripts (per page), an inline theme-bootstrap script in
+// index.html, and Angular's component-scoped <style> emissions. Nonces are
+// not viable without per-request server rendering. CDN allowlist covers
+// Font Awesome (cdnjs) + Phosphor (unpkg) icon CSS and the dashboard's
+// lazy-loaded html5-qrcode/lz-string from unpkg.
+const SHOWCASE_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://unpkg.com",
+  "script-src-attr 'none'",
+  "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://unpkg.com",
+  "font-src 'self' data: https://cdnjs.cloudflare.com https://unpkg.com",
+  "img-src 'self' data: blob:",
+  "media-src 'self' blob:",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join('; ');
+app.use((req, res, next) => {
+  res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
+  res.setHeader('Permissions-Policy', 'camera=(self), microphone=(), geolocation=(), interest-cohort=()');
+  res.setHeader('Content-Security-Policy', SHOWCASE_CSP);
+  next();
+});
+
 // Middleware
 app.use(cors({
   origin: true,


### PR DESCRIPTION
## Summary

Addresses every flagged item in Lighthouse Best Practices on `full-selfbrowsing.com`.

| Item | Fix |
|---|---|
| **Browser errors were logged to the console** | Dockerfile now copies `showcase/js/` into the build context so `/assets/dashboard-runtime-state.js` ships. Was 404ing on every route (referenced from `index.html` body). |
| **Use a strong HSTS policy** | \`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload\` |
| **Ensure proper origin isolation with COOP** | \`Cross-Origin-Opener-Policy: same-origin-allow-popups\` |
| **Mitigate clickjacking with XFO or CSP** | \`X-Frame-Options: DENY\` + CSP \`frame-ancestors 'none'\` |
| **Ensure CSP is effective against XSS attacks** | CSP allowlist for the existing CDN icon imports (Font Awesome on cdnjs, Phosphor on unpkg) + dashboard's lazy-loaded unpkg scripts |

Plus a few standard hardening lines: \`X-Content-Type-Options: nosniff\`, \`Referrer-Policy: strict-origin-when-cross-origin\`, \`Permissions-Policy\` (camera=(self), microphone=(), geolocation=(), interest-cohort=()), \`app.disable('x-powered-by')\`.

## Not in scope

**Trusted Types** (\`require-trusted-types-for 'script'\`) is intentionally NOT enforced. Angular emits inline component styles and the showcase injects JSON-LD scripts at runtime via Renderer2. Enforcing Trusted Types without a per-request nonce/policy would require either SSR with dynamic nonces or rewriting every JSON-LD injector to use a declared TT policy. Larger follow-up.

The CSP keeps \`'unsafe-inline'\` for \`script-src\` and \`style-src\` for the same reason. The header still earns Lighthouse credit for *having* a CSP with object-src 'none', base-uri 'self', frame-ancestors 'none', and form-action 'self'; switching to nonces removes the \`'unsafe-inline'\` and graduates to a strict CSP.

## Test plan

- [x] \`node --check showcase/server/server.js\` passes
- [x] Diff is minimal (Dockerfile +1 line, server.js +36 lines)
- [ ] CI passes (extension, mcp, showcase build+crawler smoke, all-green)
- [ ] Fly deploy succeeds
- [ ] \`curl -I https://full-selfbrowsing.com/\` shows all headers
- [ ] \`/assets/dashboard-runtime-state.js\` returns 200 (was 404)
- [ ] All 5 marketing routes still render correctly (smoke crawler)
- [ ] Dashboard QR scan + LZ-string decompression still work (CSP allows unpkg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)