### PR TITLE
fix(deploy): whitelist showcase/js/ in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !showcase/server/
 !showcase/angular/
 !showcase/assets/
+!showcase/js/
 
 # Re-ignore things inside those dirs we don't need
 showcase/server/node_modules


### PR DESCRIPTION
## Summary

PR #37 added \`COPY showcase/js/ ../js/\` to the Dockerfile but the Fly build failed because \`.dockerignore\` excludes \`showcase/js/\` from the build context. Quick one-line addition to the allowlist.

\`\`\`
ERROR: failed to fetch an image or build from source: error building:
failed to solve: failed to compute cache key: failed to calculate checksum
of ref ...: "/showcase/js": not found
\`\`\`

## Test plan

- [ ] CI passes
- [ ] Fly deploy succeeds
- [ ] \`/assets/dashboard-runtime-state.js\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)