### PR TITLE
fix(showcase): restore icon rendering + ASCII hyphen page titles

### DIFF
--- a/showcase/angular/src/app/pages/about/about-page.component.ts
+++ b/showcase/angular/src/app/pages/about/about-page.component.ts
@@ -4,7 +4,7 @@ import { Title, Meta } from '@angular/platform-browser';
 const HOST = 'https://full-selfbrowsing.com';
 const OG_IMAGE = `${HOST}/assets/fsb_logo_dark.png`;
 const OG_IMAGE_ALT = 'FSB Full Self-Browsing logo';
-const SITE_NAME = 'FSB \u2014 Full Self-Browsing';
+const SITE_NAME = 'FSB - Full Self-Browsing';
 const YOUTUBE_CHANNEL = 'https://www.youtube.com/@parzival5707';
 
 const DEMO_VIDEOS = [
@@ -52,7 +52,7 @@ export class AboutPageComponent implements OnInit {
 
   ngOnInit(): void {
     const url = `${HOST}/about`;
-    const t = 'FSB \u2014 About';
+    const t = 'FSB - About';
     const d = 'Watch real FSB demos: Grok 4.1 e-commerce autopilot, Codex MCP flight booking, OpenClaw monitoring, and Claude-powered browser iteration.';
     this.applyMeta(t, d, url);
     this.injectDemoVideoJsonLd();

--- a/showcase/angular/src/app/pages/agents/agents-page.component.ts
+++ b/showcase/angular/src/app/pages/agents/agents-page.component.ts
@@ -4,7 +4,7 @@ import { Title, Meta } from '@angular/platform-browser';
 const HOST = 'https://full-selfbrowsing.com';
 const OG_IMAGE = `${HOST}/assets/fsb_logo_dark.png`;
 const OG_IMAGE_ALT = 'FSB Full Self-Browsing logo';
-const SITE_NAME = 'FSB \u2014 Full Self-Browsing';
+const SITE_NAME = 'FSB - Full Self-Browsing';
 
 @Component({
   selector: 'app-agents-page',
@@ -20,7 +20,7 @@ export class AgentsPageComponent implements OnInit {
 
   ngOnInit(): void {
     const url = `${HOST}/agents`;
-    const t = 'FSB \u2014 Agents (OpenClaw Skill + MCP)';
+    const t = 'FSB - Agents (OpenClaw Skill + MCP)';
     const d = 'Drive your real Chrome from OpenClaw, Claude, Codex, Cursor, and more. Install the FSB OpenClaw skill in 3 steps and use 50+ MCP tools to act, observe, verify.';
     this.applyMeta(t, d, url);
     this.injectAgentsPageJsonLd();

--- a/showcase/angular/src/app/pages/home/home-page.component.ts
+++ b/showcase/angular/src/app/pages/home/home-page.component.ts
@@ -7,7 +7,7 @@ import { APP_VERSION } from '../../core/seo/version';
 const HOST = 'https://full-selfbrowsing.com';
 const OG_IMAGE = `${HOST}/assets/fsb_logo_dark.png`;
 const OG_IMAGE_ALT = 'FSB Full Self-Browsing logo';
-const SITE_NAME = 'FSB \u2014 Full Self-Browsing';
+const SITE_NAME = 'FSB - Full Self-Browsing';
 const YOUTUBE_CHANNEL = 'https://www.youtube.com/@parzival5707';
 
 @Component({
@@ -29,7 +29,7 @@ export class HomePageComponent implements OnInit {
 
   ngOnInit(): void {
     const url = HOST; // home canonical: 'https://full-selfbrowsing.com' (no trailing slash, per D-02)
-    const t = 'FSB \u2014 Full Self-Browsing';
+    const t = 'FSB - Full Self-Browsing';
     const d = 'Open-source Chrome extension for AI-powered browser automation through natural language, with an MCP server for Claude Code, Codex, Cursor, and other agents.';
     this.applyMeta(t, d, url);
     this.injectSoftwareApplicationJsonLd();

--- a/showcase/angular/src/app/pages/privacy/privacy-page.component.ts
+++ b/showcase/angular/src/app/pages/privacy/privacy-page.component.ts
@@ -5,7 +5,7 @@ import { Title, Meta } from '@angular/platform-browser';
 const HOST = 'https://full-selfbrowsing.com';
 const OG_IMAGE = `${HOST}/assets/fsb_logo_dark.png`;
 const OG_IMAGE_ALT = 'FSB Full Self-Browsing logo';
-const SITE_NAME = 'FSB \u2014 Full Self-Browsing';
+const SITE_NAME = 'FSB - Full Self-Browsing';
 
 @Component({
   selector: 'app-privacy-page',
@@ -21,7 +21,7 @@ export class PrivacyPageComponent implements OnInit {
 
   ngOnInit(): void {
     const url = `${HOST}/privacy`;
-    const t = 'FSB \u2014 Privacy';
+    const t = 'FSB - Privacy';
     const d = 'How FSB handles your data: API keys encrypted in Chrome local storage, no telemetry, automation runs locally in your browser. BYO key, BYO browser.';
     this.applyMeta(t, d, url);
   }

--- a/showcase/angular/src/app/pages/support/support-page.component.ts
+++ b/showcase/angular/src/app/pages/support/support-page.component.ts
@@ -5,7 +5,7 @@ import { Title, Meta } from '@angular/platform-browser';
 const HOST = 'https://full-selfbrowsing.com';
 const OG_IMAGE = `${HOST}/assets/fsb_logo_dark.png`;
 const OG_IMAGE_ALT = 'FSB Full Self-Browsing logo';
-const SITE_NAME = 'FSB \u2014 Full Self-Browsing';
+const SITE_NAME = 'FSB - Full Self-Browsing';
 
 // Plain-text mirror of the Support FAQ for Schema.org FAQPage JSON-LD.
 // Keep in sync with support-page.component.html.
@@ -82,7 +82,7 @@ export class SupportPageComponent implements OnInit {
 
   ngOnInit(): void {
     const url = `${HOST}/support`;
-    const t = 'FSB \u2014 Support';
+    const t = 'FSB - Support';
     const d = 'Get help with FSB: setup guides, MCP configuration, troubleshooting, GitHub issues, and direct contact for the open-source Chrome extension.';
     this.applyMeta(t, d, url);
     this.injectSupportFaqJsonLd();

--- a/showcase/angular/src/styles.scss
+++ b/showcase/angular/src/styles.scss
@@ -1,26 +1,6 @@
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css');
 @import url('https://unpkg.com/@phosphor-icons/web@2.1.1/src/regular/style.css');
 
-/* PERF: font-display swap overrides. CDN icon CSS omits font-display, leaving browsers in the
-   default "block" period (300 ms invisible-icon flash). These declarations merge with the
-   upstream @font-face by font-family name and only update font-display. */
-@font-face { font-family: 'Font Awesome 6 Free';   font-display: swap; }
-@font-face { font-family: 'Font Awesome 6 Brands'; font-display: swap; }
-@font-face { font-family: 'Phosphor';              font-display: swap; }
-
-/* PERF: CLS mitigation. Reserve 1em inline slot for icon-font glyphs so late icon-stylesheet
-   load does not shift surrounding inline content. Icons already render at 1em width once their
-   font loads; this just claims the slot earlier. Steady-state visual is identical. */
-i[class^="ph "], i[class*=" ph "],
-i.fa-solid, i.fa-regular, i.fa-brands, i[class^="fa-"], i[class*=" fa-"] {
-  display: inline-block;
-  width: 1em;
-  min-width: 1em;
-  line-height: 1;
-  text-align: center;
-  font-style: normal;
-}
-
 /* Shared showcase foundation: tokens, reset, typography, and utilities only. */
 :root {
   --primary: #ff6b35;


### PR DESCRIPTION
## Summary

Two unrelated UI fixes bundled per user direction.

### 1) Restore Font Awesome + Phosphor icon rendering

PR #35 shipped two \`styles.scss\` additions that broke icon glyphs in production:

\`\`\`scss
@font-face { font-family: 'Font Awesome 6 Free';   font-display: swap; }
@font-face { font-family: 'Font Awesome 6 Brands'; font-display: swap; }
@font-face { font-family: 'Phosphor';              font-display: swap; }

i[class^="ph "], i[class*=" ph "],
i.fa-solid, i.fa-regular, i.fa-brands, i[class^="fa-"], i[class*=" fa-"] {
  display: inline-block; width: 1em; min-width: 1em;
  line-height: 1; text-align: center; font-style: normal;
}
\`\`\`

Per CSS Fonts L4 the \`src\`-less \`@font-face\` overrides should merge descriptors with the upstream rules, but several browsers (Safari notably) instead treat them as creating new fontface entries with no resource URLs — which breaks the font loader. The icon-slot reservation interacts with Phosphor's ligature rendering in ways we did not validate in real browsers.

This commit removes both blocks. CDN \`@import\` lines remain so icons load via their original cascade. Lighthouse will regain the \"font-display 300 ms\" insight and icon-driven CLS, accepted in this round; self-hosting the icon fonts is the right long-term fix and is intentionally NOT in scope here.

### 2) Page titles use single ASCII hyphen

\`'FSB \\u2014 Page'\` -> \`'FSB - Page'\` across home/about/agents/privacy/support.

## Test plan

- [x] \`npm run build\` clean — 5 prerendered routes
- [x] Bundled \`styles-*.css\` contains zero \`font-display:swap\` and zero icon-slot rule
- [x] CDN \`@import\` for Font Awesome + Phosphor still present
- [x] \`smoke-crawler.mjs\` 48/48 PASS against local dist
- [x] Each prerendered route's \`<title>\` is \`FSB - <Page>\` with ASCII hyphen
- [ ] CI green
- [ ] Fly deploy succeeds
- [ ] Live icons render (visual check post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)