### PR TITLE
fix(showcase): drop CSP script-src-attr 'none' (icon-breaker)

### DIFF
--- a/showcase/server/server.js
+++ b/showcase/server/server.js
@@ -39,10 +39,16 @@ app.disable('x-powered-by');
 // not viable without per-request server rendering. CDN allowlist covers
 // Font Awesome (cdnjs) + Phosphor (unpkg) icon CSS and the dashboard's
 // lazy-loaded html5-qrcode/lz-string from unpkg.
+// NOTE: script-src-attr is intentionally NOT set to 'none' here. Angular 20
+// emits the lazy-CSS pattern `<link rel="stylesheet" media="print"
+// onload="this.media='all'">` for the global styles bundle; setting
+// script-src-attr to 'none' blocks that onload handler, leaving the bundle
+// stuck at media="print" so its @import for Font Awesome / Phosphor never
+// applies to screen rendering -- icons disappear. Without an explicit
+// script-src-attr, it falls back to script-src which permits 'unsafe-inline'.
 const SHOWCASE_CSP = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' https://unpkg.com",
-  "script-src-attr 'none'",
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://unpkg.com",
   "font-src 'self' data: https://cdnjs.cloudflare.com https://unpkg.com",
   "img-src 'self' data: blob:",


### PR DESCRIPTION
## Summary

Production icons (Font Awesome + Phosphor) have been invisible since PR #37 shipped the CSP — the cause was NOT the @font-face overrides I reverted in PR #39, but a different CSP directive:

\`\`\`
script-src-attr 'none'
\`\`\`

## Root cause

Angular 20 ships the global stylesheet with the lazy-CSS pattern:

\`\`\`html
<link rel=\"stylesheet\" href=\"styles-XXXX.css\"
      media=\"print\" onload=\"this.media='all'\">
\`\`\`

\`media=\"print\"\` keeps the stylesheet non-blocking, then the \`onload\` inline event handler flips it to \`media=\"all\"\` so the styles actually apply to screen rendering.

\`script-src-attr 'none'\` blocks every inline event handler — including this onload. The bundle loaded but stayed at \`media=\"print\"\`, so the entire global stylesheet was effectively dead on screen. That includes its \`@import\` lines for Font Awesome (cdnjs) and Phosphor (unpkg). Net result: every icon vanished on every route, even though CSP allowlisted both CDN origins in \`style-src\` + \`font-src\`.

## Fix

Remove the \`script-src-attr 'none'\` directive. Per CSP3 spec, without an explicit \`script-src-attr\`, it falls back to \`script-src\`, which has \`'unsafe-inline'\`. The onload handler runs, the bundle activates for screen, the @imports load, icons render.

The CSP still has \`script-src 'self' 'unsafe-inline' https://unpkg.com\` for the existing inline JSON-LD and Angular component scripts, and inline event handlers were always permitted through that path — we just had a stricter override that the lazy-CSS pattern couldn't tolerate.

Comment added to the SHOWCASE_CSP constant explaining the trap so the next person doesn't put it back.

## Test plan

- [x] \`node --check showcase/server/server.js\` passes
- [ ] CI green
- [ ] Fly deploy succeeds
- [ ] \`curl -I\` on prod shows CSP without script-src-attr
- [ ] Icons render on home + every other route (visual check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)