### PR TITLE
fix(showcase): allow YouTube embeds in CSP frame-src

### DIFF
--- a/showcase/server/server.js
+++ b/showcase/server/server.js
@@ -51,9 +51,12 @@ const SHOWCASE_CSP = [
   "script-src 'self' 'unsafe-inline' https://unpkg.com",
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://unpkg.com",
   "font-src 'self' data: https://cdnjs.cloudflare.com https://unpkg.com",
-  "img-src 'self' data: blob:",
+  "img-src 'self' data: blob: https://i.ytimg.com",
   "media-src 'self' blob:",
   "connect-src 'self'",
+  // YouTube embeds on the /about page require frame-src; without this it falls
+  // back to default-src 'self' and the demo videos render as a blocked iframe.
+  "frame-src https://www.youtube.com https://www.youtube-nocookie.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",


### PR DESCRIPTION
## Summary

Demo videos on \`/about\` were blocked by CSP. The CSP has no explicit \`frame-src\`, so iframes fall back to \`default-src 'self'\` — only same-origin iframes allowed, YouTube embeds blocked.

Same class of bug as PR #40 (missing CSP directive interacting with a real feature). Added:

\`\`\`
frame-src https://www.youtube.com https://www.youtube-nocookie.com
\`\`\`

Also added \`https://i.ytimg.com\` to \`img-src\` so the YouTube player can load poster thumbnails.

\`frame-ancestors 'none'\` (clickjacking protection — who can frame US) is unchanged.

## Test plan

- [x] syntax check passes
- [ ] CI green
- [ ] Fly deploy succeeds
- [ ] \`curl -I\` on prod shows \`frame-src\` for both YouTube origins
- [ ] /about page YouTube embeds visibly play

🤖 Generated with [Claude Code](https://claude.com/claude-code)