### PR TITLE
fix(deploy): bump angular-build stage to node:24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS angular-build
+FROM node:24-alpine AS angular-build
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary

Fly.io deploy job on the v0.9.63 merge commit (#42) failed during `npm ci` in the angular-build stage of the Dockerfile. Lock-file resolution drift between local npm 11 and node:20-alpine's npm 10.8.2 caused npm 10 to report `Missing: @types/node@25.7.0 from lock file` even though the lock is internally consistent under npm 11.

Root cause: the Phase 261-03 ESLint v9 + typescript-eslint + angular-eslint dep additions introduce peer-dep resolution paths that npm 10 reads as a strict-mode lockfile mismatch. Local `npm ci --dry-run` succeeds; Docker's npm 10.8.2 fails on the same lockfile.

Fix: bump the angular-build stage to `node:24-alpine` (npm 11.x, matches local toolchain). The production runtime stage stays on `node:20-alpine` -- the server lockfile resolves cleanly under either npm version, and this change is build-only.

## Test plan

- [ ] PR CI (`ci / all-green`) passes
- [ ] Post-merge Fly deploy job succeeds (`npm ci` in angular-build stage exits 0)
- [ ] Showcase serves at the Fly URL with all 30 prerendered HTMLs intact