### PR TITLE
fix(i18n): footer picker selected state + Accept-Language middleware mount order

### DIFF
--- a/showcase/angular/src/app/layout/language-picker/language-picker.component.html
+++ b/showcase/angular/src/app/layout/language-picker/language-picker.component.html
@@ -5,11 +5,10 @@
   <span class="lang-picker__sr" i18n="@@picker.sr.label">Choose language</span>
   <select
     class="lang-picker__select"
-    [value]="current"
     (change)="onChange($event)"
     i18n-aria-label="@@picker.aria.label"
     aria-label="Choose language"
   >
-    <option *ngFor="let code of locales" [value]="code" [attr.translate]="'no'">{{ code.toUpperCase() }}</option>
+    <option *ngFor="let code of locales" [value]="code" [selected]="code === current" [attr.translate]="'no'">{{ code.toUpperCase() }}</option>
   </select>
 </label>

--- a/showcase/angular/src/locale/messages.xlf
+++ b/showcase/angular/src/locale/messages.xlf
@@ -13,7 +13,7 @@
         <source>Choose language</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/language-picker/language-picker.component.html</context>
-          <context context-type="linenumber">11,13</context>
+          <context context-type="linenumber">10,12</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.brand.logo.alt" datatype="html">

--- a/showcase/server/server.js
+++ b/showcase/server/server.js
@@ -141,6 +141,16 @@ app.get(Object.keys(htmlRedirects), (req, res) => {
   res.redirect(301, htmlRedirects[req.path]);
 });
 
+// Phase 267 / ROUTE-03: Accept-Language auto-detection on bare `/`.
+// Cookie-respecting (fsb-locale wins), bot-safe (no header => no redirect),
+// 302 (caches must not pin the decision). Must run BEFORE express.static so
+// a redirect short-circuits the prerendered index.html send for `/`.
+app.use(createAcceptLanguageMiddleware({
+  supported: LOCALES.filter(l => l !== SOURCE_LOCALE),
+  defaultLocale: 'en',
+  cookieName: 'fsb-locale',
+}));
+
 if (staticPath) {
   app.use(express.static(staticPath, {
     maxAge: 0,
@@ -164,16 +174,6 @@ if (staticPath) {
     }
   }));
 }
-
-// Phase 267 / ROUTE-03: Accept-Language auto-detection on bare `/`.
-// Cookie-respecting (fsb-locale wins), bot-safe (no header => no redirect),
-// 302 (caches must not pin the decision). Runs BEFORE marketing-routes block so
-// a redirect short-circuits the static-file send.
-app.use(createAcceptLanguageMiddleware({
-  supported: LOCALES.filter(l => l !== SOURCE_LOCALE),
-  defaultLocale: 'en',
-  cookieName: 'fsb-locale',
-}));
 
 // Phase 216 SRV-01 / SRV-02 / D-09 / D-10:
 // Prefer per-route prerendered HTML for marketing routes; whitelist /dashboard


### PR DESCRIPTION
## Summary

Two post-v0.9.63 hotfixes bundled into one PR.

### 1. Footer language picker resets to "EN" after switching
- **Symptom:** changing language via the footer dropdown navigates correctly to the new locale, but the dropdown on the destination page displays "EN" instead of the active locale.
- **Cause:** `<select [value]="current">` paired with `*ngFor`-rendered `<option>`s is a known Angular property-binding race — the select's value is set before its options exist, so it falls back to the first option (`en`).
- **Fix:** drop the `[value]` on `<select>`, mark the matching option with `[selected]="code === current"` instead.

### 2. Accept-Language auto-redirect on `/` never fires in production
- **Symptom:** Phase 267 (ROUTE-03) Accept-Language middleware does not redirect bare `/` to the matching locale subpath. Reported via VPN testing; reproduced against production with curl (`ja`, `de`, `es` all returned 200 with identical etag — middleware dead).
- **Cause:** `createAcceptLanguageMiddleware` was mounted AFTER `express.static` in `showcase/server/server.js`. Express runs middleware in registration order; the prerendered `index.html` was served before the redirect could run. The Phase 267 unit test calls the middleware in isolation with mocked req/res — never booted the express app — so the mount-order regression slipped through.
- **Fix:** move the `app.use(createAcceptLanguageMiddleware(...))` block to immediately before the `express.static` mount.

## Test plan

- [x] `node tests/server-accept-language.test.js` → 42/42 PASS
- [x] Local smoke against `server.js`:
  - `GET / + Accept-Language: ja` → `302 /ja/`
  - `GET / + Accept-Language: de-DE,de;q=0.9` → `302 /de/`
  - `GET / + Accept-Language: en-US` → pass-through
- [ ] CI all-green
- [ ] Post-merge: re-curl production with `Accept-Language: ja` and confirm `302 /ja/`
- [ ] Manual: footer picker on `/ja/` displays "JA", on `/de/` displays "DE", etc.

## Follow-up (not in this PR)

Add a supertest-based integration test that boots `server.js` and asserts mount-order behavior. Would have caught #2 at Phase 267 land. WARNING-02 (cookie short-circuit) remains deferred — unaffected by this fix.