### PR TITLE
fix(extension): record visual-session tick on navigate NO_OWNED_TAB bootstrap

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "name": "FSB v0.9.62",
-  "version": "0.9.62",
+  "name": "FSB v0.9.64",
+  "version": "0.9.64",
   "description": "FSB - Universal AI-powered browser automation assistant with multi-model support",
   "permissions": [
     "activeTab",

--- a/extension/ws/mcp-bridge-client.js
+++ b/extension/ws/mcp-bridge-client.js
@@ -733,7 +733,20 @@ class MCPBridgeClient {
       : { success: false, code: 'AGENT_REGISTRY_UNAVAILABLE', agentId });
     if (resolved.success === false) {
       if (toolName === 'navigate' && resolved.code === 'NO_OWNED_TAB') {
-        return dispatchWithoutResolvedTab(buildRouteParams());
+        // Codex PR #33 P2 -- navigate bootstrap parity with open_tab/switch_tab.
+        // The NO_OWNED_TAB branch creates the agent's first owned tab via
+        // navigate's dispatcher path; mirror the post-dispatch visual-session
+        // lifecycle from lines 705-728 so the implicit visual session is
+        // started/refreshed on success and final-cleared when sidecar.isFinal.
+        const dispatched = await dispatchWithoutResolvedTab(buildRouteParams());
+        if (dispatched && dispatched.success === true) {
+          const resolvedTabId = Number.isFinite(dispatched && dispatched.tabId) ? dispatched.tabId : null;
+          if (resolvedTabId !== null) {
+            await this._recordVisualSessionTickIfPresent(resolvedTabId, agentId, payload);
+            await this._clearVisualSessionIfFinal(resolvedTabId, agentId, payload);
+          }
+        }
+        return dispatched;
       }
       // Surface plain-object error envelope; bridge serializes to MCP shape.
       return resolved;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsb-full-self-browsing",
-  "version": "0.9.62",
+  "version": "0.9.64",
   "description": "FSB - Full Self-Browsing: An intelligent, open-source Chrome extension for AI-powered browser automation using natural language instructions",
   "main": "background.js",
   "homepage": "https://github.com/lakshmanturlapati/FSB",
@@ -19,7 +19,7 @@
     "test:mcp-smoke": "npm --prefix mcp run build && node tests/mcp-lifecycle-smoke.test.js && node tests/mcp-tool-smoke.test.js",
     "lint": "echo \"Linting not configured yet\"",
     "clean": "rm -f config/dev-settings.json",
-    "package": "zip -r fsb-v0.9.60.zip . -x '*.git*' 'node_modules/*' 'config/dev-*'",
+    "package": "zip -r fsb-v0.9.64.zip . -x '*.git*' 'node_modules/*' 'config/dev-*'",
     "package:extension": "node scripts/package-extension.mjs",
     "package:skill": "node scripts/package-skill.mjs",
     "showcase:install": "npm --prefix showcase/angular install",
@@ -114,7 +114,7 @@
     {
       "description": "Version",
       "href": "https://github.com/lakshmanturlapati/FSB/releases",
-      "url": "https://img.shields.io/badge/version-0.9.60-blue.svg"
+      "url": "https://img.shields.io/badge/version-0.9.64-blue.svg"
     },
     {
       "description": "License",

--- a/showcase/angular/package-lock.json
+++ b/showcase/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "showcase-angular",
-  "version": "0.9.62",
+  "version": "0.9.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "showcase-angular",
-      "version": "0.9.62",
+      "version": "0.9.64",
       "dependencies": {
         "@angular/animations": "^20.3.19",
         "@angular/common": "^20.3.19",

--- a/showcase/angular/package.json
+++ b/showcase/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showcase-angular",
-  "version": "0.9.62",
+  "version": "0.9.64",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/tests/mcp-visual-session-contract.test.js
+++ b/tests/mcp-visual-session-contract.test.js
@@ -372,8 +372,17 @@ async function runImplicitDispatcherValidationCase() {
   console.log('\n--- Case 3: implicit dispatcher validation -- VISUAL_FIELDS_REQUIRED + BADGE_NOT_ALLOWED ---');
 
   const BUILD_PATH = path.resolve(__dirname, '..', 'mcp', 'build', 'tools', 'manual.js');
+  const SRC_PATH = path.resolve(__dirname, '..', 'mcp', 'src', 'tools', 'manual.ts');
   if (!fs.existsSync(BUILD_PATH)) {
-    console.error('  FAIL: mcp/build/tools/manual.js missing -- run `cd mcp && npm run build` before this test');
+    console.error('  FAIL: mcp/build/tools/manual.js missing -- run `npm --prefix mcp run build` before this test');
+    failed++;
+    return;
+  }
+  // Staleness guard: a build older than the source has caused phantom "contract
+  // hole" failures (build predates validateVisualSessionFields). Fail loud with
+  // remediation rather than running stale code.
+  if (fs.existsSync(SRC_PATH) && fs.statSync(SRC_PATH).mtimeMs > fs.statSync(BUILD_PATH).mtimeMs) {
+    console.error('  FAIL: mcp/build/tools/manual.js is older than mcp/src/tools/manual.ts -- run `npm --prefix mcp run build` to refresh');
     failed++;
     return;
   }

--- a/tests/visual-session-schema-lock.test.js
+++ b/tests/visual-session-schema-lock.test.js
@@ -132,8 +132,15 @@ check(getReadOnlyTools().length === 15,
 // -------------------------------------------------------------------
 
 const BUILD_PATH = path.resolve(__dirname, '..', 'mcp', 'build', 'tools', 'manual.js');
+const SRC_PATH = path.resolve(__dirname, '..', 'mcp', 'src', 'tools', 'manual.ts');
 if (!fs.existsSync(BUILD_PATH)) {
-  console.error('  FAIL: mcp/build/tools/manual.js missing -- run `cd mcp && npm run build` before this test (root npm test chain does this automatically).');
+  console.error('  FAIL: mcp/build/tools/manual.js missing -- run `npm --prefix mcp run build` before this test (root npm test chain does this automatically).');
+  process.exit(1);
+}
+// Staleness guard: a build older than the source has caused phantom contract
+// failures. Fail loud with remediation rather than importing stale code.
+if (fs.existsSync(SRC_PATH) && fs.statSync(SRC_PATH).mtimeMs > fs.statSync(BUILD_PATH).mtimeMs) {
+  console.error('  FAIL: mcp/build/tools/manual.js is older than mcp/src/tools/manual.ts -- run `npm --prefix mcp run build` to refresh');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Addresses Codex P2 from PR #33 (v0.9.62 Implicit Visual Session Contract). The `navigate` recovery branch for `NO_OWNED_TAB` returned early via `dispatchWithoutResolvedTab(...)` and never recorded an implicit visual-session lifecycle tick, leaving the contract inconsistent with the `open_tab` / `switch_tab` bootstrap paths.
- Mirrors the post-dispatch pattern from `mcp-bridge-client.js:705-728`: await the dispatch, on `success === true` extract `dispatched.tabId`, then call `_recordVisualSessionTickIfPresent` and `_clearVisualSessionIfFinal`. Skips the tick on failed dispatch.
- Adds a build-staleness guard to `tests/mcp-visual-session-contract.test.js` and `tests/visual-session-schema-lock.test.js` so a stale `mcp/build/tools/manual.js` fails loud with a remediation message (`npm --prefix mcp run build`) instead of producing phantom "contract hole" failures from pre-Phase-255 compiled code.

## Scope
- **Extension only.** No MCP server or showcase changes. Reload the Chrome extension to see the effect.

## Test plan
- [x] `node --check extension/ws/mcp-bridge-client.js`
- [x] `node tests/mcp-visual-tick-lifecycle.test.js` (79/79)
- [x] `node tests/recovery-tools-bootstrap.test.js` (66/66)
- [x] `node tests/visual-session-reentry.test.js`, `visual-session-agent-scoped.test.js` (16/16)
- [x] `node tests/agent-tab-resolver.test.js` (30/30), `ownership-error-codes.test.js` (23/23)
- [x] `node tests/mcp-visual-session-contract.test.js` (116/116 after MCP rebuild)
- [x] `node tests/visual-session-schema-lock.test.js` (314/314 after MCP rebuild)
- [x] Staleness guard verified: touched build mtime to 2020 → both tests bail with actionable error; after `npm --prefix mcp run build` both pass.
- [ ] Manual smoke: load extension, agent's first `navigate` with no owned tab → confirm visual-session overlay starts.