### PR TITLE
docs: bump display version refs 0.9.62 -> 0.9.64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FSB v0.9.62 Full Self Browsing
+# FSB v0.9.64 Full Self Browsing
 
 <div align="center">
 
@@ -9,7 +9,7 @@
 </picture>
 
 ![FSB](https://img.shields.io/badge/FSB-Full_Self_Browsing-000000?style=for-the-badge)
-![Version](https://img.shields.io/badge/version-0.9.62-0078D4?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-0.9.64-0078D4?style=for-the-badge)
 ![Manifest V3](https://img.shields.io/badge/Manifest_V3-Chrome-34A853?style=for-the-badge&logo=googlechrome&logoColor=white)
 ![License](https://img.shields.io/badge/license-BSL_1.1-F5C518?style=for-the-badge)
 
@@ -32,7 +32,7 @@
 
 FSB (Full Self Browsing) is an open source Chrome extension for AI powered browser automation. Describe a task in plain English; FSB reads the live DOM, builds a plan, executes browser actions, verifies results, and reports progress through the popup, side panel, or MCP.
 
-> FSB v0.9.62 is functional and production ready for supervised automation. Browser automation can still behave unpredictably on complex or sensitive sites, so monitor actions and test on non critical pages first.
+> FSB v0.9.64 is functional and production ready for supervised automation. Browser automation can still behave unpredictably on complex or sensitive sites, so monitor actions and test on non critical pages first.
 
 ### Why DOM First
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,6 +1,6 @@
 # FSB Chrome Extension
 
-`extension/` is the unpacked Chrome extension package for FSB v0.9.62. Load this directory, not the repository root, when running locally.
+`extension/` is the unpacked Chrome extension package for FSB v0.9.64. Load this directory, not the repository root, when running locally.
 
 ## Load Unpacked
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -531,7 +531,7 @@ The build command copies `extension/ai/tool-definitions.js` into `mcp/ai/tool-de
 
 ### Versioning
 
-The MCP package has its own version (`0.9.0`) because it is published independently from the extension release (`0.9.62`). When extension bridge contracts change, update both the MCP version metadata and the compatibility notes in this README. When only website or extension UI text changes, the MCP version usually does not need to move.
+The MCP package has its own version (`0.9.0`) because it is published independently from the extension release (`0.9.64`). When extension bridge contracts change, update both the MCP version metadata and the compatibility notes in this README. When only website or extension UI text changes, the MCP version usually does not need to move.
 
 Contract-sensitive changes should be covered by tests before publishing:
 

--- a/store-assets/chrome-web-store/listing-copy.md
+++ b/store-assets/chrome-web-store/listing-copy.md
@@ -2,7 +2,7 @@
 
 ## Title
 
-FSB v0.9.62
+FSB v0.9.64
 
 ## Summary
 


### PR DESCRIPTION
## Summary
- Bumps display-version references missed by the v0.9.64 release commit: root README title/badge/intro, `extension/README.md`, `store-assets/chrome-web-store/listing-copy.md`, and the `mcp/README.md` versioning section's extension-release reference.
- Leaves historical phase/milestone references intact (`v0.9.62 visual-session contract`, `.planning/v0.9.62-CONTRACT.md`, changelog entries, skill-side references). Those name a shipped milestone artifact, not the current release.

## Note on the v0.9.64 tag
The `v0.9.64` GitHub release was already cut from `b6b819a` and does not include these README updates. The doc refs will be correct on `main` going forward; the tagged snapshot stays where it is (releases shouldn't move once published). Next release tag will pick these up cleanly.

## Test plan
- [x] `grep "0\.9\.62" README.md extension/README.md store-assets/chrome-web-store/listing-copy.md` returns no matches.
- [ ] CI: extension, mcp, showcase jobs green.