### PR TITLE
fix(visual-session): add Hermes to MCP client allowlist

### DIFF
--- a/extension/utils/mcp-visual-session.js
+++ b/extension/utils/mcp-visual-session.js
@@ -13,7 +13,8 @@
     'OpenClaw',
     'OpenClaw 🦀',
     'Grok',
-    'Gemini'
+    'Gemini',
+    'Hermes'
   ];
 
   var CLIENT_LABEL_MAP = Object.create(null);

--- a/mcp/src/tools/visual-session.ts
+++ b/mcp/src/tools/visual-session.ts
@@ -8,7 +8,7 @@ import { mapFSBError } from '../errors.js';
 // Approved visual-session client labels (must match the extension's allowlist)
 const MCP_VISUAL_CLIENT_LABELS: string[] = [
   'Claude', 'Codex', 'ChatGPT', 'Perplexity', 'Windsurf',
-  'Cursor', 'Antigravity', 'OpenCode', 'OpenClaw', 'OpenClaw 🦀', 'Grok', 'Gemini',
+  'Cursor', 'Antigravity', 'OpenCode', 'OpenClaw', 'OpenClaw 🦀', 'Grok', 'Gemini', 'Hermes',
 ];
 
 const CLIENT_LABEL_MAP: Record<string, string> = Object.create(null);


### PR DESCRIPTION
## Summary
- Closes #47. Adds `'Hermes'` to the trusted MCP visual-session client allowlist on both the MCP side (`mcp/src/tools/visual-session.ts`) and the extension-side mirror (`extension/utils/mcp-visual-session.js`).
- Without this, every action-tool call from a Hermes-labeled client was rejected with `Visual session contract` / `Client label "Hermes" is not on the trusted v0.9.36 badge allowlist`.

## Test plan
- [x] `node tests/mcp-visual-session-contract.test.js` passes (116/116)
- [x] `node tests/visual-session-schema-lock.test.js` passes (314/314)
- [x] `npm --prefix mcp run build` clean
- [ ] CI green