### PR TITLE
hotfix: serve /stats SPA shell on showcase server (was 404 in prod)

### DIFF
--- a/showcase/server/server.js
+++ b/showcase/server/server.js
@@ -203,7 +203,7 @@ app.use((req, res, next) => {
     return next();
   }
   if (!staticPath) {
-    if (marketingRoutes.has(req.path) || req.path === '/dashboard') {
+    if (marketingRoutes.has(req.path) || req.path === '/dashboard' || req.path === '/stats') {
       res.status(503).type('text/plain').send('Showcase build not found. Run `npm --prefix showcase/angular run build` first.');
       return;
     }
@@ -221,9 +221,10 @@ app.use((req, res, next) => {
     // will surface this on the next run.
     return next();
   }
-  if (req.path === '/dashboard') {
-    // D-10 exact-match whitelist: /dashboard is the only SPA-shell route.
-    // /dashboard/anything is NOT covered and falls through to 404.
+  if (req.path === '/dashboard' || req.path === '/stats') {
+    // D-10 exact-match whitelist: /dashboard and /stats are SPA-shell routes
+    // (RenderMode.Client per app.routes.server.ts). /dashboard/* and /stats/*
+    // are NOT covered and fall through to 404.
     res.sendFile(path.join(staticPath, 'index.html'));
     return;
   }


### PR DESCRIPTION
## Summary

Quick task 260514-1nv shipped the \`/stats\` Angular page with \`RenderMode.Client\` but missed updating \`showcase/server/server.js\`'s exact-match whitelist (which serves the SPA shell for \`/dashboard\`). v0.9.69 deploy went green, but \`https://full-selfbrowsing.com/stats\` returned 404 on first hit.

Two-line fix in \`showcase/server/server.js\` — adds \`/stats\` to:
1. The build-not-found 503 guard (consistent with /dashboard).
2. The exact-match SPA-shell serve branch (mirrors /dashboard pattern verbatim).

\`/stats/*\` (trailing path) still falls through to 404 — same Easter-egg posture (footer link to bare \`/stats\` is the only entry).

## Test plan

- [x] Local: \`npm test\` exit 0
- [ ] CI all-green
- [ ] Post-deploy: \`curl -sI https://full-selfbrowsing.com/stats\` returns 200 + the SPA index.html (with the chart.js lazy chunk fetched client-side)
- [ ] Post-deploy: \`/stats/foo\` (trailing path) still 404 (Easter-egg invariant)