### PR TITLE
ci(chrome-extension): install showcase/server + showcase/angular deps so npm test passes

### DIFF
--- a/.github/workflows/chrome-extension.yml
+++ b/.github/workflows/chrome-extension.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Install mcp deps
         run: npm --prefix mcp install --no-audit --no-fund
 
+      - name: Install showcase/server deps (needed by server-telemetry tests in npm test chain)
+        run: npm --prefix showcase/server install --no-audit --no-fund
+
+      - name: Install showcase/angular deps (needed by fsb-telemetry-service + build-smoke + privacy-page tests in npm test chain)
+        run: npm --prefix showcase/angular install --no-audit --no-fund
+
       - name: Validate extension
         run: npm run validate:extension
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -83,6 +83,7 @@ Total: 11 items. Triage via `/gsd-debug` and `/gsd-cleanup` during a future mile
 | 260514-pu4 | Wire showcase/server + showcase/angular deps into ci.yml extension job for v0.9.69 PR checks | 2026-05-14 | fbbdae2 | [260514-pu4-wire-showcase-server-showcase-angular-de](./quick/260514-pu4-wire-showcase-server-showcase-angular-de/) |
 | 260514-r6i | Fix showcase CSP `connect-src` so /stats Easter-egg page can fetch from api.github.com (cumulative-stars + commits + forks + issues + PRs + maintenance charts were dark in prod) | 2026-05-15 | a70d550 | [260514-r6i-fix-csp-on-showcase-server-to-unblock-st](./quick/260514-r6i-fix-csp-on-showcase-server-to-unblock-st/) |
 | 260514-rm4 | Fix two Codex P1 telemetry bugs from PR #50 review: (1) serialize recordDispatch fsbUsageData rmw to stop concurrent-dispatch row loss; (2) strip `attempts` from POST body so server allowlist doesn't 400 retried events | 2026-05-15 | 2e514c1 | [260514-rm4-fix-two-p1-telemetry-bugs-from-codex-pr-](./quick/260514-rm4-fix-two-p1-telemetry-bugs-from-codex-pr-/) |
+| 260514-w34 | Add showcase/server + showcase/angular install steps to chrome-extension.yml (mirror of 260514-pu4 for the on-push-to-main auto-zip workflow; fixes MODULE_NOT_FOUND better-sqlite3 from run 25899440149) | 2026-05-15 | 5cb4869 | [260514-w34-fix-chrome-extension-yml-dep-gap-add-sho](./quick/260514-w34-fix-chrome-extension-yml-dep-gap-add-sho/) |
 
 ## Pending User-Gated Actions (carry-forward)
 

--- a/.planning/quick/260514-w34-fix-chrome-extension-yml-dep-gap-add-sho/260514-w34-PLAN.md
+++ b/.planning/quick/260514-w34-fix-chrome-extension-yml-dep-gap-add-sho/260514-w34-PLAN.md
@@ -1,0 +1,52 @@
+---
+phase: quick-260514-w34
+plan: 01
+type: quick
+description: Add showcase/server + showcase/angular install steps to chrome-extension.yml so npm test can find better-sqlite3 + chart.js
+files_modified:
+  - .github/workflows/chrome-extension.yml
+must_haves:
+  truths:
+    - "`.github/workflows/chrome-extension.yml`'s `validate, test, package` job installs showcase/server deps BEFORE `npm test` (so the ~13 server-telemetry tests find better-sqlite3, express-rate-limit, ws)"
+    - "Same workflow installs showcase/angular deps BEFORE `npm test` (so fsb-telemetry-service + build-smoke + privacy-page tests find chart.js + Angular CLI)"
+    - "ci.yml is unchanged (already correct from quick task 260514-pu4)"
+    - "Workflow trigger filter, job structure, and packaging steps are untouched"
+  artifacts:
+    - ".github/workflows/chrome-extension.yml — 6 lines added (2 step blocks, 3 lines each)"
+  key_links:
+    - "260514-pu4 — the equivalent fix for ci.yml; this is the same pattern applied to a different workflow file"
+    - "GitHub Actions run 25899440149 — the failing chrome-extension run that triggered this fix (MODULE_NOT_FOUND better-sqlite3)"
+---
+
+# Plan: Add showcase deps to chrome-extension.yml
+
+## Context
+
+`chrome-extension.yml` runs `npm test` (line 46) on every push to main and on extension-v* tags, but only installs root + mcp deps. The full `npm test` chain post-v0.9.69 includes ~13 server-telemetry tests requiring `showcase/server` deps and 4 Angular/server integration tests requiring `showcase/angular` deps. Quick task 260514-pu4 fixed this for `ci.yml` but `chrome-extension.yml` was missed.
+
+## Task: Add showcase deps install steps
+
+**File:** `.github/workflows/chrome-extension.yml`
+
+**Action:** After the "Install mcp deps" step (line 39-40), insert two new step blocks mirroring the 260514-pu4 ci.yml fix:
+
+```yaml
+      - name: Install showcase/server deps (needed by server-telemetry tests in npm test chain)
+        run: npm --prefix showcase/server install --no-audit --no-fund
+
+      - name: Install showcase/angular deps (needed by fsb-telemetry-service + build-smoke + privacy-page tests in npm test chain)
+        run: npm --prefix showcase/angular install --no-audit --no-fund
+```
+
+Keep all other steps unchanged: "Validate extension" → "Run extension and bridge tests" → "Package Chrome extension" remain in place after.
+
+**Done when:**
+- New steps appear at lines 42-46 (between mcp install and validate extension)
+- `grep -c "npm --prefix showcase/server install" .github/workflows/chrome-extension.yml` → 1
+- `grep -c "npm --prefix showcase/angular install" .github/workflows/chrome-extension.yml` → 1
+- YAML structural sanity (steps present, ordering correct)
+- ONE commit: `ci(chrome-extension): install showcase/server + showcase/angular deps so npm test finds better-sqlite3 + chart.js`
+
+## Verification (post-merge)
+
+Next push to `main` after merge will run chrome-extension.yml automatically. Expected outcome: full npm test chain (now ~108 tests including the just-added recorder/telemetry/csp regression tests) passes, packaging step proceeds.

--- a/.planning/quick/260514-w34-fix-chrome-extension-yml-dep-gap-add-sho/260514-w34-SUMMARY.md
+++ b/.planning/quick/260514-w34-fix-chrome-extension-yml-dep-gap-add-sho/260514-w34-SUMMARY.md
@@ -1,0 +1,42 @@
+---
+phase: quick-260514-w34
+plan: 01
+status: complete
+date: 2026-05-15
+---
+
+# Summary: chrome-extension.yml showcase deps wire-up
+
+## What changed
+
+One edit to `.github/workflows/chrome-extension.yml` — added two install steps after the existing mcp deps install and before the validate-extension step, so `npm test` finds `better-sqlite3` (from showcase/server) and `chart.js` (from showcase/angular).
+
+**Before:** root install → mcp install → validate → `npm test` → package
+**After:**  root install → mcp install → **showcase/server install → showcase/angular install** → validate → `npm test` → package
+
+## Root cause
+
+`chrome-extension.yml` (the on-push-to-main + on-tag auto-zip + GitHub-Release workflow) was never updated when v0.9.69 expanded `npm test` to include ~13 server-telemetry tests and 4 Angular/server integration tests. Quick task **260514-pu4** fixed the same gap in `ci.yml` (the PR-check workflow), but `chrome-extension.yml` is a separate file and was missed.
+
+Surfaced by GitHub Actions run **25899440149** (post-merge of PR #52): `Error: Cannot find module 'better-sqlite3'`, `code: 'MODULE_NOT_FOUND'`, exit code 1 at one of the server-telemetry tests in the chain.
+
+## Verification
+
+- `grep -c "npm --prefix showcase/server install" .github/workflows/chrome-extension.yml` → 1 ✓
+- `grep -c "npm --prefix showcase/angular install" .github/workflows/chrome-extension.yml` → 1 ✓
+- `grep -c "npm --prefix showcase/server install" .github/workflows/ci.yml` → 1 (unchanged, pre-existing from 260514-pu4) ✓
+- `grep -c "npm --prefix showcase/angular install" .github/workflows/ci.yml` → 2 (unchanged) ✓
+- New steps ordering: server install @ line 42, angular install @ line 45, `npm test` step @ line 51 — install steps strictly before npm test ✓
+- YAML structural sanity passed (jobs/steps present, 6 `- name:` entries: was 4, +2)
+
+## Commit
+
+`5cb4869` `ci(chrome-extension): install showcase/server + showcase/angular deps so npm test finds better-sqlite3 + chart.js`
+
+## Files
+
+- `.github/workflows/chrome-extension.yml` — 6 lines added (2 step blocks)
+
+## Validation timing
+
+`chrome-extension.yml` runs only on push to `main` (matching its paths-ignore filter) and on `extension-v*` tags. The next merge to main will auto-trigger and validate the fix end-to-end (full npm test chain green + zip artifact uploaded).


### PR DESCRIPTION
## Why

The \`chrome-extension.yml\` workflow (on-push-to-main + on-extension-v* auto-zip + GitHub-Release) was failing on every main push since v0.9.69 landed. Symptom on [run 25899440149](https://github.com/LakshmanTurlapati/FSB/actions/runs/25899440149) (after PR #52 merged):

\`\`\`
Error: Cannot find module 'better-sqlite3'
code: 'MODULE_NOT_FOUND'
##[error]Process completed with exit code 1.
\`\`\`

Root cause: \`chrome-extension.yml\` installs only root + mcp deps before running \`npm test\`, but the expanded test chain now includes ~13 server-telemetry tests requiring \`showcase/server\` deps and 4 Angular/server integration tests requiring \`showcase/angular\` deps.

This is the exact same gap that **quick task 260514-pu4** fixed for \`ci.yml\` (the PR-check workflow) — but \`chrome-extension.yml\` is a separate workflow file and was missed at the time.

## What

Six-line edit to \`.github/workflows/chrome-extension.yml\`: add two install steps between "Install mcp deps" and "Validate extension", matching the 260514-pu4 pattern exactly.

\`\`\`diff
       - name: Install mcp deps
         run: npm --prefix mcp install --no-audit --no-fund

+      - name: Install showcase/server deps (needed by server-telemetry tests in npm test chain)
+        run: npm --prefix showcase/server install --no-audit --no-fund
+
+      - name: Install showcase/angular deps (needed by fsb-telemetry-service + build-smoke + privacy-page tests in npm test chain)
+        run: npm --prefix showcase/angular install --no-audit --no-fund
+
       - name: Validate extension
         run: npm run validate:extension
\`\`\`

## Out of scope

- \`ci.yml\` (already correct per 260514-pu4)
- Test script chain (unchanged)
- Workflow trigger filter or job structure (unchanged)
- Package.json, manifests, versions (unchanged)

## Test plan

- [x] \`grep -c "npm --prefix showcase/server install" .github/workflows/chrome-extension.yml\` → 1
- [x] \`grep -c "npm --prefix showcase/angular install" .github/workflows/chrome-extension.yml\` → 1
- [x] New steps appear before "Run extension and bridge tests" (line 42, 45 < line 51)
- [x] Structural sanity (steps/jobs present, ordering correct)
- [ ] **Post-merge:** the merge commit will trigger \`chrome-extension.yml\` automatically on main; the full npm test chain (~108 tests including the new csp + recorder + collector regression tests) should pass and the packaging step should produce \`fsb-extension-v0.9.65.zip\`.

## Related

- quick task 260514-pu4 (the equivalent ci.yml fix)
- PR #52, #53 (the recent merges that exposed this latent gap)

## Quick task

Tracked at \`.planning/quick/260514-w34-fix-chrome-extension-yml-dep-gap-add-sho/\`.