### PR TITLE
chore(mcp): bump fsb-mcp-server 0.9.0 -> 0.9.1 to ship Hermes allowlist fix

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `fsb-mcp-server` are documented in this file. Each entry corresponds to a published npm release; FSB extension milestones map to MCP package versions in the entry header.
 
+<a id="v0.9.1"></a>
+
+## 0.9.1 (2026-05-16)
+
+Milestone: FSB v0.9.69 follow-up. Patch release adding `Hermes` to the v0.9.36 shared MCP client allowlist so the implicit visual-session contract (v0.9.0) accepts `client: "Hermes"` without raising `BADGE_NOT_ALLOWED`.
+
+### Fixes
+
+- **Add `Hermes` to the MCP client allowlist.** Action-tool calls that pass `client: "Hermes"` previously rejected at the schema layer with the typed `BADGE_NOT_ALLOWED` error (see the v0.9.0 entry for the contract). `Hermes` is now an approved client label alongside Claude, Codex, ChatGPT, Perplexity, Windsurf, Cursor, Antigravity, OpenCode, OpenClaw, Grok, and Gemini. Closes #47 via PR #49 (commit `1512cb48`).
+
+### Anti-scope (NOT in 0.9.1)
+
+- No dependency bumps; `@modelcontextprotocol/sdk`, `ws`, `zod`, `strip-json-comments`, `smol-toml`, and `yaml` are unchanged from 0.9.0.
+- No protocol changes; the v0.9.0 implicit visual-session contract (`visual_reason` + `client` required, sliding 60s window, `is_final: true` early-clear) is byte-identical.
+- No new typed errors; `VISUAL_FIELDS_REQUIRED`, `BADGE_NOT_ALLOWED`, and `TOOL_REMOVED` retain their v0.9.0 shape.
+- Final `npm publish fsb-mcp-server@0.9.1` remains user-gated post-merge per the v0.9.0 precedent.
+
 <a id="v0.9.0"></a>
 
 ## 0.9.0 (2026-05-11)

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsb-mcp-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "FSB Browser Automation MCP Server",
   "license": "BUSL-1.1",
   "author": "Lakshman Turlapati",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.lakshmanturlapati/fsb-mcp-server",
   "title": "FSB MCP Server",
   "description": "Control the FSB browser extension from any MCP client using a local stdio or Streamable HTTP companion runtime.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "fsb-mcp-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/version.ts
+++ b/mcp/src/version.ts
@@ -1,5 +1,5 @@
 export const FSB_SERVER_NAME = 'fsb';
-export const FSB_MCP_VERSION = '0.9.0';
+export const FSB_MCP_VERSION = '0.9.1';
 export const FSB_EXTENSION_BRIDGE_PORT = 7225;
 export const FSB_EXTENSION_BRIDGE_URL = `ws://localhost:${FSB_EXTENSION_BRIDGE_PORT}`;
 export const DEFAULT_HTTP_HOST = '127.0.0.1';

--- a/tests/mcp-version-parity.test.js
+++ b/tests/mcp-version-parity.test.js
@@ -22,7 +22,7 @@ function assertEqual(actual, expected, msg) {
 }
 
 const repoRoot = path.resolve(__dirname, '..');
-const canonicalVersion = '0.9.0';
+const canonicalVersion = '0.9.1';
 
 function readText(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');


### PR DESCRIPTION
## Summary

- Bumps `mcp/package.json` from `0.9.0` to `0.9.1` and prepends a matching `0.9.1` entry to `mcp/CHANGELOG.md`.
- Pure release plumbing: the `Hermes` allowlist source change already landed via PR #49 (commit `1512cb48`) on 2026-05-14, but `mcp/package.json` was never bumped, so npm-published `fsb-mcp-server@0.9.0` (last publish 2026-05-12) still rejects `client: "Hermes"` with `BADGE_NOT_ALLOWED`.

## Why this is a separate PR

PR #49 added `Hermes` to the v0.9.36 shared MCP client allowlist in two source files:

- `mcp/src/tools/visual-session.ts:11`
- `extension/utils/mcp-visual-session.js:17`

…but the package version stayed at `0.9.0`, so no publish has happened. Users running the published binary keep hitting:

> Client label "Hermes" is not on the trusted v0.9.36 badge allowlist.

This PR is the missing version bump + changelog entry that lets the next `npm publish fsb-mcp-server` actually ship the fix to npm. Closes #47 in conjunction with the prior PR #49.

## Anti-scope

- Does **not** run `npm publish` -- final publish remains user-gated (or CI-triggered via `.github/workflows/npm-publish.yml`).
- Does **not** touch any allowlist source -- `Hermes` was already correct in source.
- Does **not** bump the extension manifest, the showcase app version (`showcase/angular/src/app/core/seo/version.ts`), or any other `package.json`.
- Does **not** alter the implicit visual-session contract or any typed errors -- `BADGE_NOT_ALLOWED` retains its v0.9.0 shape.
- No dependency bumps; `@modelcontextprotocol/sdk`, `ws`, `zod`, `strip-json-comments`, `smol-toml`, `yaml` are unchanged.

## Files changed (exactly 2)

- `mcp/package.json` -- single field bump `"version": "0.9.0"` -> `"0.9.1"`
- `mcp/CHANGELOG.md` -- new `<a id="v0.9.1"></a>` + `## 0.9.1 (2026-05-16)` section above the existing 0.9.0 entry, referencing PR #49 and commit `1512cb48`

## Test plan

- [ ] Inspect the diff -- confirm only `mcp/package.json` and `mcp/CHANGELOG.md` are touched.
- [ ] After merge, trigger `.github/workflows/npm-publish.yml` (or `npm publish` from `mcp/`).
- [ ] `npm view fsb-mcp-server version` returns `0.9.1`.
- [ ] Re-install MCP host, send an action tool call with `client: "Hermes"`, confirm it no longer returns `BADGE_NOT_ALLOWED`.