### PR TITLE
chore(mcp): bump fsb-mcp-server 0.9.1 -> 0.9.2 to ship numeric-param coercion

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `fsb-mcp-server` are documented in this file. Each entry corresponds to a published npm release; FSB extension milestones map to MCP package versions in the entry header.
 
+<a id="v0.9.2"></a>
+
+## 0.9.2 (2026-05-16)
+
+Milestone: FSB v0.9.69 follow-up. Patch release that coerces string-encoded numeric tool params (`tabId`, `tab_id`, `count`, `limit`, `topN`, etc.) so MCP clients that serialize integers as JSON strings can call the tools without being rejected at the schema gate.
+
+### Fixes
+
+- **Coerce string-encoded numeric params.** Some MCP clients (observed: Claude Code) serialize integer tool params as JSON strings on the wire. The server's Zod input schemas previously declared bare `z.number()`, so `mcp__fsb__switch_tab({ tabId: "695936610" })` and any other tool with a numeric field rejected with `Expected number, received string`. The `jsonSchemaToZod` translator (`mcp/src/tools/schema-bridge.ts`) now emits `z.coerce.number().finite()` for `'number'` and `z.coerce.number().int().finite()` for `'integer'`, both wrapped in a `z.preprocess` that maps `""` to `NaN` so empty-string never silently coerces to `0`. Seven hand-rolled Zod sites that bypass the translator received the same swap: `agents.ts:35` (back), `vault.ts:60` + `vault.ts:110` (fill_credential, use_payment_method), `visual-session.ts:50` (start_visual_session), `observability.ts:27/68/91` (limit, count, topN). PR #63 (commit `fae2aa01`).
+
+### Anti-scope (NOT in 0.9.2)
+
+- No dependency bumps; `@modelcontextprotocol/sdk`, `ws`, `zod`, `strip-json-comments`, `smol-toml`, and `yaml` are unchanged from 0.9.1.
+- No protocol changes; the implicit visual-session contract (v0.9.0) is byte-identical.
+- No new typed errors; the existing schema-failure error shape is preserved.
+- No JSON-Schema-source edits (`mcp/ai/tool-definitions.cjs` untouched; byte-identity parity test stays green).
+- Final `npm publish fsb-mcp-server@0.9.2` remains user-gated post-merge per the v0.9.0 / v0.9.1 precedent.
+
 <a id="v0.9.1"></a>
 
 ## 0.9.1 (2026-05-16)

--- a/mcp/build/version.d.ts
+++ b/mcp/build/version.d.ts
@@ -1,5 +1,5 @@
 export declare const FSB_SERVER_NAME = "fsb";
-export declare const FSB_MCP_VERSION = "0.9.0";
+export declare const FSB_MCP_VERSION = "0.9.2";
 export declare const FSB_EXTENSION_BRIDGE_PORT = 7225;
 export declare const FSB_EXTENSION_BRIDGE_URL = "ws://localhost:7225";
 export declare const DEFAULT_HTTP_HOST = "127.0.0.1";

--- a/mcp/build/version.js
+++ b/mcp/build/version.js
@@ -1,5 +1,5 @@
 export const FSB_SERVER_NAME = 'fsb';
-export const FSB_MCP_VERSION = '0.9.0';
+export const FSB_MCP_VERSION = '0.9.2';
 export const FSB_EXTENSION_BRIDGE_PORT = 7225;
 export const FSB_EXTENSION_BRIDGE_URL = `ws://localhost:${FSB_EXTENSION_BRIDGE_PORT}`;
 export const DEFAULT_HTTP_HOST = '127.0.0.1';

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsb-mcp-server",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "FSB Browser Automation MCP Server",
   "license": "BUSL-1.1",
   "author": "Lakshman Turlapati",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.lakshmanturlapati/fsb-mcp-server",
   "title": "FSB MCP Server",
   "description": "Control the FSB browser extension from any MCP client using a local stdio or Streamable HTTP companion runtime.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "fsb-mcp-server",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/version.ts
+++ b/mcp/src/version.ts
@@ -1,5 +1,5 @@
 export const FSB_SERVER_NAME = 'fsb';
-export const FSB_MCP_VERSION = '0.9.1';
+export const FSB_MCP_VERSION = '0.9.2';
 export const FSB_EXTENSION_BRIDGE_PORT = 7225;
 export const FSB_EXTENSION_BRIDGE_URL = `ws://localhost:${FSB_EXTENSION_BRIDGE_PORT}`;
 export const DEFAULT_HTTP_HOST = '127.0.0.1';

--- a/tests/mcp-version-parity.test.js
+++ b/tests/mcp-version-parity.test.js
@@ -22,7 +22,7 @@ function assertEqual(actual, expected, msg) {
 }
 
 const repoRoot = path.resolve(__dirname, '..');
-const canonicalVersion = '0.9.1';
+const canonicalVersion = '0.9.2';
 
 function readText(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');


### PR DESCRIPTION
## Summary

Release plumbing for the numeric-param coercion fix landed in PR #63 (commit \`fae2aa01\`). Bumps the package version across all 5 in-tree sites + rebuilds the version artifact so the next \`npm publish fsb-mcp-server\` carries the fix to MCP clients.

## Why now

PR #63 fixed the server-side schema so MCP clients (observed: Claude Code) can pass tool params with string-encoded integers (\`tabId: \"695936610\"\`) without being rejected by Zod. That fix is on \`main\` but NOT on npm — the published \`fsb-mcp-server@0.9.1\` (2026-05-16) still has the bug. Every Claude-Code-as-MCP-client call to \`switch_tab\` / \`close_tab\` / \`read_page\` / etc. fails today.

## Changes

| File | Change |
|------|--------|
| \`mcp/package.json\` | \`0.9.1\` -> \`0.9.2\` |
| \`mcp/server.json\` | top-level + \`packages[0]\` -> \`0.9.2\` |
| \`mcp/src/version.ts\` | \`FSB_MCP_VERSION = '0.9.2'\` |
| \`mcp/build/version.{js,d.ts}\` | rebuilt artifact -> \`0.9.2\` |
| \`tests/mcp-version-parity.test.js\` | \`canonicalVersion = '0.9.2'\` |
| \`mcp/CHANGELOG.md\` | new \`## 0.9.2 (2026-05-16)\` entry citing PR #63 |

## Anti-scope

- No code logic changes, no protocol changes, no dependency bumps.
- No JSON-Schema-source edits.
- Final \`cd mcp && npm publish\` remains user-gated post-merge per the v0.9.0 / v0.9.1 precedent.

## Test plan

- [x] \`npm --prefix mcp run build\` -> exit 0 (tsc + build/version.js regenerated; both now report 0.9.2)
- [x] \`node tests/mcp-version-parity.test.js\` -> 10/10 PASS
- [x] \`npm test\` (root) -> exit 0

## Operational follow-up (user-gated)

After merge:
\`\`\`
cd mcp && npm publish
\`\`\`

Tag + GitHub release optional per prior pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)