### PR TITLE
feat(stats): trim auto-refresh copy + Live badge + tab-aware metrics

### DIFF
--- a/showcase/angular/src/app/pages/stats/stats-page.component.html
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.html
@@ -1,7 +1,7 @@
 <section class="stats-page container">
   <header class="stats-header">
-    <h1>FSB <span class="dot">·</span> Stats <span class="muted">for nerds</span></h1>
-    <p class="stats-sub">Live signals from <code>LakshmanTurlapati/FSB</code>. Auto-refreshes every 5&nbsp;minutes while this tab is visible.</p>
+    <h1>FSB <span class="dot">·</span> Stats <span class="muted">for nerds</span> <span class="stats-live-badge" role="status" aria-label="Live data">Live</span></h1>
+    <p class="stats-sub">Live signals from <code>LakshmanTurlapati/FSB</code>.</p>
   </header>
 
   <nav class="view-switcher" role="tablist" aria-label="Stats view">
@@ -18,34 +18,39 @@
     }
   </nav>
 
-  <!-- Phase 274 / STATS-02 -- FSB Telemetry section heading + live headline row. -->
-  <div class="fsb-section-heading" role="region"
-       aria-label="FSB Telemetry"
-       i18n-aria-label="@@SHOWCASE_STATS_FSB_SECTION_ARIA">
-    <h2 i18n="@@SHOWCASE_STATS_FSB_SECTION_HEADING"><span [attr.translate]="'no'">FSB</span> Telemetry</h2>
-    <p class="fsb-section-sub" i18n="@@SHOWCASE_STATS_FSB_SECTION_SUB">Live anonymous usage from <span [attr.translate]="'no'">FSB</span> installs. Refreshes every 5&nbsp;minutes.</p>
-  </div>
-
-  @if (fsbHeadline) {
-    <div class="stats-headline" role="status" aria-live="polite"
-         aria-label="Live FSB metrics"
-         i18n-aria-label="@@SHOWCASE_STATS_FSB_HEADLINE_ARIA">
-      <span class="headline-cell">
-        <strong>{{ fsbHeadline.active_users_now }}</strong>
-        <span i18n="@@SHOWCASE_STATS_FSB_HEADLINE_ACTIVE">active right now</span>
-      </span>
-      <span class="headline-dot" aria-hidden="true">·</span>
-      <span class="headline-cell">
-        <strong>{{ fsbHeadline.total_users }}</strong>
-        <span i18n="@@SHOWCASE_STATS_FSB_HEADLINE_TOTAL">total users</span>
-      </span>
-      <span class="headline-dot" aria-hidden="true">·</span>
-      <span class="headline-cell">
-        <strong>{{ fsbHeadline.tokens_24h }}</strong>
-        <span i18n="@@SHOWCASE_STATS_FSB_HEADLINE_TOKENS">tokens (last 24h)</span>
-      </span>
+  <div class="stats-headline-row">
+    <div class="stats-tab-metrics" role="status" aria-live="polite" aria-label="Current tab metrics">
+      @for (m of tabMetrics; track m.label) {
+        <span class="headline-cell">
+          <strong>{{ m.value }}</strong>
+          <span>{{ m.label }}</span>
+        </span>
+        @if (!$last) {
+          <span class="headline-dot" aria-hidden="true">·</span>
+        }
+      }
     </div>
-  }
+    @if (fsbHeadline) {
+      <div class="stats-headline" role="status" aria-live="polite"
+           aria-label="Live FSB metrics"
+           i18n-aria-label="@@SHOWCASE_STATS_FSB_HEADLINE_ARIA">
+        <span class="headline-cell">
+          <strong>{{ fsbHeadline.active_users_now }}</strong>
+          <span i18n="@@SHOWCASE_STATS_FSB_HEADLINE_ACTIVE">active right now</span>
+        </span>
+        <span class="headline-dot" aria-hidden="true">·</span>
+        <span class="headline-cell">
+          <strong>{{ fsbHeadline.total_users }}</strong>
+          <span i18n="@@SHOWCASE_STATS_FSB_HEADLINE_TOTAL">total users</span>
+        </span>
+        <span class="headline-dot" aria-hidden="true">·</span>
+        <span class="headline-cell">
+          <strong>{{ fsbHeadline.tokens_24h }}</strong>
+          <span i18n="@@SHOWCASE_STATS_FSB_HEADLINE_TOKENS">tokens (last 24h)</span>
+        </span>
+      </div>
+    }
+  </div>
 
   <div class="chart-card" [attr.data-state]="viewState">
     @if (viewState === 'loading') {
@@ -97,7 +102,4 @@
     }
   </div>
 
-  <footer class="stats-foot">
-    <p>Live from the <a href="https://docs.github.com/en/rest" target="_blank" rel="noopener">GitHub REST API</a>. Auto-refreshes every 5&nbsp;minutes.</p>
-  </footer>
 </section>

--- a/showcase/angular/src/app/pages/stats/stats-page.component.scss
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.scss
@@ -214,12 +214,21 @@
   }
 }
 
-.stats-headline {
+.stats-headline-row {
   display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.stats-tab-metrics,
+.stats-headline {
+  display: inline-flex;
   align-items: baseline;
   flex-wrap: wrap;
   gap: 0.5rem 0.75rem;
-  margin-bottom: 1rem;
   padding: 0.75rem 1rem;
   background: var(--bg-elevated);
   border: 1px solid var(--border-color);
@@ -243,6 +252,27 @@
   .headline-dot {
     color: var(--text-muted);
     font-size: 1.1rem;
+  }
+}
+
+.stats-tab-metrics {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.stats-headline {
+  flex: 0 1 auto;
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .stats-headline-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .stats-headline {
+    margin-left: 0;
   }
 }
 
@@ -290,4 +320,35 @@
   width: 100%;
   height: 100%;
   display: block;
+}
+
+.stats-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: 0.5rem;
+  padding: 0.2rem 0.55rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 0.55em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  vertical-align: middle;
+
+  &::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--primary);
+    animation: stats-live-pulse 2.2s ease-in-out infinite;
+  }
+}
+
+@keyframes stats-live-pulse {
+  0%, 100% { opacity: 1;    transform: scale(1); }
+  50%      { opacity: 0.45; transform: scale(0.9); }
 }

--- a/showcase/angular/src/app/pages/stats/stats-page.component.ts
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.ts
@@ -129,6 +129,147 @@ export class StatsPageComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.latestFsbHeadline;
   }
 
+  /**
+   * Tab-aware metrics for the LHS of the headline row. Returns 2 cells
+   * computed from the currently loaded dataset relevant to selectedView.
+   * Empty arrays produce 0s / em-dashes; the row is always rendered so the
+   * layout does not jump as data arrives. Labels are English-only to match
+   * the page's pre-274 baseline (GitHub view labels are also English-only).
+   */
+  get tabMetrics(): ReadonlyArray<{ label: string; value: string }> {
+    const dayMs = 86_400_000;
+    const sinceDays = (n: number): number => Date.now() - n * dayMs;
+    const fh = this.latestFsbHeadline;
+
+    switch (this.selectedView) {
+      case 'stars-cumulative': {
+        const cutoff = sinceDays(7);
+        const last7 = this.latestStars.filter(
+          (s) => !Number.isNaN(Date.parse(s.starred_at)) && Date.parse(s.starred_at) >= cutoff
+        ).length;
+        return [
+          { label: 'total stars', value: this.formatNum(this.latestStars.length) },
+          { label: 'last 7 days', value: this.formatNum(last7) },
+        ];
+      }
+      case 'stars-weekly': {
+        const last = this.latestWeeklyStars.at(-1);
+        const delta = last?.deltaPct ?? null;
+        const deltaStr =
+          delta === null || delta === undefined
+            ? '—'
+            : `${delta > 0 ? '+' : ''}${delta.toFixed(0)}%`;
+        return [
+          { label: 'this week', value: this.formatNum(last?.count ?? 0) },
+          { label: 'vs last week', value: deltaStr },
+        ];
+      }
+      case 'issues-open-vs-closed': {
+        const issues = this.latestIssues.filter((i) => !i.pull_request);
+        const open = issues.filter((i) => !i.closed_at).length;
+        const closed = issues.length - open;
+        return [
+          { label: 'open', value: this.formatNum(open) },
+          { label: 'closed', value: this.formatNum(closed) },
+        ];
+      }
+      case 'forks-growth': {
+        const cutoff = sinceDays(30);
+        const last30 = this.latestForks.filter(
+          (f) => !Number.isNaN(Date.parse(f.created_at)) && Date.parse(f.created_at) >= cutoff
+        ).length;
+        return [
+          { label: 'total forks', value: this.formatNum(this.latestForks.length) },
+          { label: 'last 30 days', value: this.formatNum(last30) },
+        ];
+      }
+      case 'prs-opened-vs-merged': {
+        const merged = this.latestPrs.filter((p) => p.merged_at).length;
+        const open = this.latestPrs.filter((p) => !p.closed_at && !p.merged_at).length;
+        return [
+          { label: 'merged', value: this.formatNum(merged) },
+          { label: 'open', value: this.formatNum(open) },
+        ];
+      }
+      case 'commits-cumulative':
+      case 'commits-over-time': {
+        const windowDays = this.selectedView === 'commits-over-time' ? 7 : 30;
+        const cutoff = sinceDays(windowDays);
+        const recent = this.latestCommits.filter((c) => {
+          const t = Date.parse(c?.commit?.author?.date ?? '');
+          return !Number.isNaN(t) && t >= cutoff;
+        }).length;
+        return [
+          { label: 'total commits', value: this.formatNum(this.latestCommits.length) },
+          { label: `last ${windowDays} days`, value: this.formatNum(recent) },
+        ];
+      }
+      case 'maintenance': {
+        const latest = this.latestReleases[0];
+        const ts = latest ? Date.parse(latest.published_at) : NaN;
+        const daysAgo = Number.isNaN(ts) ? null : Math.floor((Date.now() - ts) / dayMs);
+        return [
+          { label: 'latest release', value: latest?.tag_name ?? '—' },
+          { label: 'released', value: daysAgo === null ? '—' : `${daysAgo}d ago` },
+        ];
+      }
+      case 'fsb-active-now':
+        return [
+          { label: 'active agents', value: this.formatNum(fh?.active_agents_now ?? 0) },
+          { label: 'avg per user', value: (fh?.avg_agents_per_user ?? 0).toFixed(1) },
+        ];
+      case 'fsb-tokens':
+        return [
+          { label: 'tokens lifetime', value: this.formatBig(fh?.tokens_total_lifetime ?? 0) },
+          { label: 'tokens 24h', value: this.formatBig(fh?.tokens_24h ?? 0) },
+        ];
+      case 'fsb-agents-running':
+        return [
+          { label: 'active agents', value: this.formatNum(fh?.active_agents_now ?? 0) },
+          { label: 'lifetime agents', value: this.formatNum(fh?.total_agents_lifetime ?? 0) },
+        ];
+      case 'fsb-popular-agents': {
+        const arr = fh?.popular_agents ?? [];
+        const top = arr[0];
+        return [
+          { label: 'tracked agents', value: this.formatNum(arr.length) },
+          { label: top ? `top: ${top.label}` : 'top', value: this.formatNum(top?.uniq ?? 0) },
+        ];
+      }
+      case 'fsb-popular-mcp': {
+        const arr = fh?.popular_mcp_clients ?? [];
+        const top = arr[0];
+        return [
+          { label: 'tracked clients', value: this.formatNum(arr.length) },
+          { label: top ? `top: ${top.label}` : 'top', value: this.formatNum(top?.uniq ?? 0) },
+        ];
+      }
+      case 'fsb-avg-agents-per-user': {
+        const delta = this.avgAgentsDelta;
+        const deltaStr =
+          delta === null
+            ? '—'
+            : `${delta > 0 ? '+' : ''}${delta.toFixed(2)}`;
+        return [
+          { label: 'avg agents', value: (fh?.avg_agents_per_user ?? 0).toFixed(1) },
+          { label: 'delta', value: deltaStr },
+        ];
+      }
+      default:
+        return [];
+    }
+  }
+
+  private formatNum(n: number): string {
+    return new Intl.NumberFormat('en-US').format(Math.round(n));
+  }
+
+  private formatBig(n: number): string {
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+    return this.formatNum(n);
+  }
+
   // Chart.js Chart class -- captured from the dynamic import inside
   // afterNextRender. Typed `any` because we never import the type on the
   // server bundle.

--- a/showcase/angular/src/locale/messages.xlf
+++ b/showcase/angular/src/locale/messages.xlf
@@ -2935,60 +2935,39 @@
           <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="SHOWCASE_STATS_FSB_SECTION_ARIA" datatype="html">
-        <source>FSB Telemetry</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">23,24</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="SHOWCASE_STATS_FSB_SECTION_HEADING" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>FSB<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Telemetry</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">25,26</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="SHOWCASE_STATS_FSB_SECTION_SUB" datatype="html">
-        <source>Live anonymous usage from <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>FSB<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> installs. Refreshes every 5 minutes.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">26,27</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_HEADLINE_ARIA" datatype="html">
         <source>Live FSB metrics</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">31,32</context>
+          <context context-type="linenumber">35,36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_HEADLINE_ACTIVE" datatype="html">
         <source>active right now</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">35,37</context>
+          <context context-type="linenumber">39,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_HEADLINE_TOTAL" datatype="html">
         <source>total users</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">40,42</context>
+          <context context-type="linenumber">44,46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_HEADLINE_TOKENS" datatype="html">
         <source>tokens (last 24h)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">45,50</context>
+          <context context-type="linenumber">49,53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_TILE_AVG_AGENTS_LABEL" datatype="html">
         <source>Avg agents per active user</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">70,71</context>
+          <context context-type="linenumber">75,76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_VIEW_ACTIVE_NOW" datatype="html">
@@ -3037,56 +3016,56 @@
         <source>Active users right now</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">938</context>
+          <context context-type="linenumber">1079</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_ACTIVE_NOW_LEGEND" datatype="html">
         <source>Active users (5 min window)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">943</context>
+          <context context-type="linenumber">1084</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_TOKENS_LEGEND" datatype="html">
         <source>Tokens (last 30 days)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">973</context>
+          <context context-type="linenumber">1114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_AGENTS_RUNNING_LEGEND" datatype="html">
         <source>Active agents (10 min window)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">999</context>
+          <context context-type="linenumber">1140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_PENDING" datatype="html">
         <source>Pending (k&gt;=5 floor)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1030</context>
+          <context context-type="linenumber">1171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_POPULAR_AGENTS_LEGEND" datatype="html">
         <source>Popular agents</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1037</context>
+          <context context-type="linenumber">1178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_PENDING_MCP" datatype="html">
         <source>Pending (k&gt;=5 floor)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1053</context>
+          <context context-type="linenumber">1194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_POPULAR_MCP_LEGEND" datatype="html">
         <source>Popular MCP clients</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1060</context>
+          <context context-type="linenumber">1201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="support.hero.title" datatype="html">


### PR DESCRIPTION
## Summary

The `/stats` Easter-egg page mentioned the 5-minute refresh cadence three separate times (header subtitle, FSB Telemetry section subtitle, footer attribution) and a redundant `<h2>FSB Telemetry</h2>` re-stated the page title. This PR cleans that up and makes the headline row carry actual signal for whichever tab the user is on.

- Drop the three repeated "Auto-refreshes every 5 minutes" / "Refreshes every 5 minutes" / "Live from the GitHub REST API..." lines.
- Drop the redundant `FSB Telemetry` `<h2>` block above the metrics row.
- Add a small `Live` pill badge in the `<h1>` (subtle pulsing dot in `var(--primary)`, pill styled like the view-switcher buttons) so the live-data signal stays present in one visual element instead of three text restatements.
- Split the headline row in two:
  - **RHS** keeps the existing FSB headline cells (active users / total users / tokens 24h).
  - **LHS** is a new tab-aware metric block driven by a `tabMetrics` getter that surfaces 2 cells per view, computed from the existing `latest*` data fields. Examples: `stars-cumulative` -> total stars / last 7 days; `issues-open-vs-closed` -> open / closed; `maintenance` -> latest release / released Xd ago; `fsb-popular-agents` -> tracked agents / top: <label>.
- Both blocks share the same pill styling; on screens <= 640px the row stacks (LHS over RHS).

## Notes

- Labels are English-only to match the page's pre-274 baseline (the GitHub view labels in `views[]` are also untranslated per an existing code comment). Keeps the localized build green without new XLF entries.
- Three i18n IDs (`@@SHOWCASE_STATS_FSB_SECTION_ARIA/HEADING/SUB`) drop from the template and become harmless orphans in the lint-excluded stats XLFs until the next `ng extract-i18n` sweep.
- No version bump, no new SCSS tokens.
- The `viewState === 'error'` retry text ("The page retries automatically every 5 minutes.") is intentionally untouched -- it is useful in an error state.

## Test plan

- [x] `cd showcase/angular && npm run build` exits 0, no `i18nMissingTranslation` errors
- [x] `cd showcase/angular && npm run lint:i18n` exits 0
- [ ] Visual: navigate `/stats`, confirm header has Live pill, subtitle trimmed, FSB Telemetry h2 gone, metrics row has LHS + RHS
- [ ] Cycle through all 14 view tabs and confirm LHS metrics update sensibly
- [ ] Mobile (<= 640px): metrics row stacks LHS over RHS
- [ ] Light + dark themes both render the Live badge readably