### PR TITLE
fix(stats): move Live badge to header RHS, drop uppercase

### DIFF
--- a/showcase/angular/src/app/pages/stats/stats-page.component.html
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.html
@@ -1,7 +1,10 @@
 <section class="stats-page container">
   <header class="stats-header">
-    <h1>FSB <span class="dot">·</span> Stats <span class="muted">for nerds</span> <span class="stats-live-badge" role="status" aria-label="Live data">Live</span></h1>
-    <p class="stats-sub">Live signals from <code>LakshmanTurlapati/FSB</code>.</p>
+    <div class="stats-header-text">
+      <h1>FSB <span class="dot">·</span> Stats <span class="muted">for nerds</span></h1>
+      <p class="stats-sub">Live signals from <code>LakshmanTurlapati/FSB</code>.</p>
+    </div>
+    <span class="stats-live-badge" role="status" aria-label="Live data">Live</span>
   </header>
 
   <nav class="view-switcher" role="tablist" aria-label="Stats view">

--- a/showcase/angular/src/app/pages/stats/stats-page.component.scss
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.scss
@@ -16,7 +16,16 @@
 }
 
 .stats-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
   margin-bottom: 1.5rem;
+
+  .stats-header-text {
+    min-width: 0;
+    flex: 1 1 auto;
+  }
 
   h1 {
     font-size: clamp(1.75rem, 3.2vw, 2.5rem);
@@ -323,20 +332,19 @@
 }
 
 .stats-live-badge {
+  flex: 0 0 auto;
+  align-self: center;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-left: 0.5rem;
-  padding: 0.2rem 0.55rem;
+  gap: 0.45rem;
+  padding: 0.3rem 0.7rem;
   background: var(--bg-elevated);
   border: 1px solid var(--border-color);
   border-radius: 999px;
-  font-size: 0.55em;
+  font-size: 0.8rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.01em;
   color: var(--text-secondary);
-  vertical-align: middle;
 
   &::before {
     content: '';

--- a/showcase/angular/src/locale/messages.xlf
+++ b/showcase/angular/src/locale/messages.xlf
@@ -2939,35 +2939,35 @@
         <source>Live FSB metrics</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">35,36</context>
+          <context context-type="linenumber">38,39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_HEADLINE_ACTIVE" datatype="html">
         <source>active right now</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">39,41</context>
+          <context context-type="linenumber">42,44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_HEADLINE_TOTAL" datatype="html">
         <source>total users</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">44,46</context>
+          <context context-type="linenumber">47,49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_HEADLINE_TOKENS" datatype="html">
         <source>tokens (last 24h)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">49,53</context>
+          <context context-type="linenumber">52,56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_TILE_AVG_AGENTS_LABEL" datatype="html">
         <source>Avg agents per active user</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">75,76</context>
+          <context context-type="linenumber">78,79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_VIEW_ACTIVE_NOW" datatype="html">


### PR DESCRIPTION
## Summary

Two small follow-ups to the Live badge that shipped in PR #68:

- **RHS placement** — `.stats-header` becomes a flex row. Left side keeps the h1 + subtitle inside a new `.stats-header-text` wrapper. Right side gets the badge.
- **Mixed case** — drop `text-transform: uppercase` so the pill reads "Live" instead of "LIVE". Bumped `font-size` and `padding` so the larger label fits the pill nicely.

No other changes. No XLF / i18n impact.

## Test plan

- [x] `npm run build` exits 0
- [ ] Live: header shows h1 on the left and the `[* Live]` pill on the right, label reads "Live" mixed case
- [ ] Mobile narrow: pill stays on the right with adequate gap to the h1