### PR TITLE
fix(stats): unstick skeleton on first load + pin footer to viewport bottom

### DIFF
--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
@@ -3,6 +3,39 @@
    Replicated from vanilla main.css (git ref eb99a46)
    ============================================= */
 
+/* Quick task 260517-fsf -- sticky-footer layout.
+   The shell renders <nav> (position: fixed), <main> (router-outlet sits inside
+   via <ng-content>), and <footer> as siblings inside :host. Without the flex
+   column + min-height: 100vh + flex:1 on main, short pages let the footer
+   ride up immediately below the last content row instead of being pinned to
+   the viewport bottom. This was most visible on /stats (compact page), but
+   any page with content shorter than the viewport benefits from this.
+
+   Notes:
+     - The fixed-position .nav does NOT consume layout space, so we do not
+       need padding-top here -- each page already accounts for the nav via
+       its own top padding (var(--section-padding) etc).
+     - We only set min-height: 100vh on :host, not on body, to keep the
+       blast radius minimal (body has overflow-x: hidden and other global
+       resets we do not want to disturb). */
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+:host > main {
+  // Grow to consume any leftover vertical space so the footer is pushed
+  // to the viewport bottom on short pages. We intentionally do NOT change
+  // <main>'s inner display mode (it stays in normal block flow) so existing
+  // page layouts inside <ng-content> are unaffected.
+  flex: 1 0 auto;
+}
+
+:host > .footer {
+  flex: 0 0 auto;
+}
+
 /* --- Navigation --- */
 .nav {
   position: fixed;

--- a/showcase/angular/src/app/pages/stats/stats-page.component.html
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.html
@@ -61,32 +61,43 @@
         <span class="sr-only">Loading stats…</span>
       </div>
     }
-    @if (viewState === 'ready') {
-      <div class="chart-mount">
-        <!-- Quick task 260515-mfs (P1) -- canvas stays mounted under [hidden] so
-             @ViewChild('chartCanvas') always resolves and redrawChart() can find
-             the canvas without an extra change-detection tick. redrawChart()
-             early-returns for fsb-avg-agents-per-user (component.ts:391) and
-             destroys any prior chart instance, so nothing renders onto this
-             canvas while the big-number tile is active. -->
-        <canvas #chartCanvas [hidden]="selectedView === 'fsb-avg-agents-per-user'"></canvas>
-        @if (selectedView === 'fsb-avg-agents-per-user') {
-          <!-- Quick task 260515-kw1 -- big-number tile (HTML, not canvas). The
-               tile renders in parallel with the [hidden] canvas above so the
-               chart-mount slot is reused; redrawChart() early-returns for this view. -->
-          <div class="big-number-tile" role="status" aria-live="polite">
-            <div class="big-number-label" i18n="@@SHOWCASE_STATS_FSB_TILE_AVG_AGENTS_LABEL">Avg agents per active user</div>
-            <div class="big-number-value">{{ fsbHeadline?.avg_agents_per_user ?? 0 | number:'1.1-2' }}</div>
-            @if (avgAgentsDelta !== null) {
-              <div class="big-number-delta" [class.up]="avgAgentsDelta > 0" [class.down]="avgAgentsDelta < 0">
-                <span class="delta-arrow" aria-hidden="true">{{ avgAgentsDelta > 0 ? '\u25B2' : (avgAgentsDelta < 0 ? '\u25BC' : '\u00B7') }}</span>
-                {{ avgAgentsDelta > 0 ? '+' : '' }}{{ avgAgentsDelta | number:'1.1-2' }}
-              </div>
-            }
-          </div>
-        }
-      </div>
-    }
+    <!-- Quick task 260517-fsf -- the chart-mount (and its canvas) MUST stay
+         mounted in the DOM independent of viewState so that @ViewChild('chartCanvas')
+         always resolves. Previously this was wrapped in `@if (viewState === 'ready')`,
+         which caused a first-load race: onDatasetUpdate / onFsbHeadlineUpdate
+         flipped viewState to 'ready' and synchronously called redrawChart() before
+         change-detection materialized the @if branch, so canvasRef was undefined
+         and the chart never drew. We now use [hidden] (the same workaround that
+         was already in place for the fsb-avg-agents-per-user big-number tile) so
+         the canvas is queryable from the moment the component mounts, and only
+         visually hidden while we are still in loading / rate-limited / error
+         states. The .chart-mount also stays out of the document flow when hidden
+         so the skeleton / rate-card / error-card branches above are still the
+         only visible content during their respective states. -->
+    <div class="chart-mount" [hidden]="viewState !== 'ready'">
+      <!-- Quick task 260515-mfs (P1) -- canvas stays mounted under [hidden] so
+           @ViewChild('chartCanvas') always resolves and redrawChart() can find
+           the canvas without an extra change-detection tick. redrawChart()
+           early-returns for fsb-avg-agents-per-user (component.ts:391) and
+           destroys any prior chart instance, so nothing renders onto this
+           canvas while the big-number tile is active. -->
+      <canvas #chartCanvas [hidden]="selectedView === 'fsb-avg-agents-per-user'"></canvas>
+      @if (selectedView === 'fsb-avg-agents-per-user') {
+        <!-- Quick task 260515-kw1 -- big-number tile (HTML, not canvas). The
+             tile renders in parallel with the [hidden] canvas above so the
+             chart-mount slot is reused; redrawChart() early-returns for this view. -->
+        <div class="big-number-tile" role="status" aria-live="polite">
+          <div class="big-number-label" i18n="@@SHOWCASE_STATS_FSB_TILE_AVG_AGENTS_LABEL">Avg agents per active user</div>
+          <div class="big-number-value">{{ fsbHeadline?.avg_agents_per_user ?? 0 | number:'1.1-2' }}</div>
+          @if (avgAgentsDelta !== null) {
+            <div class="big-number-delta" [class.up]="avgAgentsDelta > 0" [class.down]="avgAgentsDelta < 0">
+              <span class="delta-arrow" aria-hidden="true">{{ avgAgentsDelta > 0 ? '\u25B2' : (avgAgentsDelta < 0 ? '\u25BC' : '\u00B7') }}</span>
+              {{ avgAgentsDelta > 0 ? '+' : '' }}{{ avgAgentsDelta | number:'1.1-2' }}
+            </div>
+          }
+        </div>
+      }
+    </div>
     @if (viewState === 'rate-limited') {
       <div class="rate-card" role="status">
         <h3>GitHub rate-limited</h3>

--- a/showcase/angular/src/locale/messages.xlf
+++ b/showcase/angular/src/locale/messages.xlf
@@ -2967,7 +2967,7 @@
         <source>Avg agents per active user</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.html</context>
-          <context context-type="linenumber">78,79</context>
+          <context context-type="linenumber">90,91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_VIEW_ACTIVE_NOW" datatype="html">


### PR DESCRIPTION
## Summary

Two surgical fixes for the showcase `/stats` page reported after PRs #68 + #70 shipped.

### 1. Skeleton stuck on first load

The chart card stayed on the `Loading stats...` skeleton forever on first hard-load (most visibly on the default `stars-cumulative` view). Switching to another tab and back rendered the chart fine.

**Root cause:** classic Angular `@ViewChild` + structural `@if` race.

- The `<canvas #chartCanvas>` was wrapped inside `@if (viewState === 'ready')` (`stats-page.component.html:64`).
- On the first `loading -> ready` transition, `onDatasetUpdate` / `onFsbHeadlineUpdate` flipped `viewState = 'ready'` and **synchronously** called `redrawChart()` in the same tick.
- Change-detection had not yet materialized the `@if` branch, so `this.chartCanvas` resolved to `undefined`, and `redrawChart()` early-returned at the `if (!canvasRef) return;` guard.
- Manually toggling tabs called `setView()` -> `redrawChart()` in a later CD cycle, by which point the `@if` branch did exist, so the chart drew.

**Fix:** keep the `.chart-mount` (and the canvas inside it) mounted in the DOM independent of `viewState`. Use `[hidden]="viewState !== 'ready'"` instead of an `@if` so `@ViewChild('chartCanvas')` always resolves. This is the same `[hidden]`-based pattern that was already in place for the `fsb-avg-agents-per-user` big-number tile branch, just generalized to cover all views.

### 2. Footer floating mid-page

On `/stats` (and any other page with content shorter than the viewport) the global footer floated mid-page instead of pinning to the viewport bottom.

**Root cause:** `app-showcase-shell` renders `<nav>` (position: fixed) + `<main>` + `<footer>` as siblings inside `:host`, but `:host` had no sticky-footer layout. Without `min-height: 100vh` + `flex: 1` on `<main>`, short pages let the footer sit immediately below the last content row.

**Fix:** add the standard sticky-footer flex pattern to the shell's SCSS:

```scss
:host {
  display: flex;
  flex-direction: column;
  min-height: 100vh;
}
:host > main { flex: 1 0 auto; }
:host > .footer { flex: 0 0 auto; }
```

`<main>`'s inner display mode is left untouched, so existing page layouts inside `<ng-content>` are unaffected.

## Files changed

- `showcase/angular/src/app/pages/stats/stats-page.component.html` -- move `.chart-mount` out of `@if (ready)`, gate visibility with `[hidden]`.
- `showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss` -- sticky-footer flex layout on `:host`.
- `showcase/angular/src/locale/messages.xlf` -- auto-regenerated line-number shift for the existing `SHOWCASE_STATS_FSB_TILE_AVG_AGENTS_LABEL` trans-unit. No new i18n entries.

## Notes

- No version bump.
- Stats page strings remain English-only (the page is already in the i18n-lint exclude list).
- Build is clean (`npm run build`), `lint:i18n` is clean.

## Test plan

- [ ] Hard-load `https://full-selfbrowsing.com/stats` -- default `stars-cumulative` chart renders immediately, no manual tab-toggle needed.
- [ ] On `/stats`, the global footer pins to the viewport bottom on desktop and mobile widths.
- [ ] Switching between every chart view still renders correctly (no regression to the existing `fsb-avg-agents-per-user` big-number tile path).
- [ ] Other pages (home, about, dashboard, agents, privacy, support) still render correctly with the new sticky-footer shell layout.

Closes the two bugs reported after PRs #68 + #70.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>