### PR TITLE
[codex] Fix dashboard fullscreen screen fit

### DIFF
--- a/showcase/angular/src/app/pages/dashboard/dashboard-page.component.scss
+++ b/showcase/angular/src/app/pages/dashboard/dashboard-page.component.scss
@@ -2153,23 +2153,46 @@
 .dash-preview-maximized {
   position: fixed !important;
   inset: 0 !important;
-  display: flex !important;
-  flex-direction: column !important;
+  display: block !important;
   z-index: 100 !important;
   aspect-ratio: auto !important;
   min-height: 100vh !important;
+  height: 100vh !important;
+  height: 100dvh !important;
   border-radius: 0 !important;
   margin: 0 !important;
   border: none !important;
+  background: #000 !important;
 }
 
 .dash-preview-maximized .dash-preview-stage {
-  flex: 1 1 auto;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100% !important;
+  height: 100% !important;
+  flex: none;
   aspect-ratio: auto !important;
   min-height: 0;
 }
 
-.dash-preview-maximized .dash-preview-btn {
+.dash-preview-maximized .dash-preview-header {
+  z-index: 22;
+}
+
+.dash-preview-maximized .dash-preview-urlbar {
+  position: absolute;
+  top: 42px;
+  left: 12px;
+  right: 12px;
+  z-index: 21;
+  border: 1px solid rgba(255, 241, 232, 0.10);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.26);
+}
+
+.dash-preview-maximized .dash-preview-btn,
+.dash-preview-maximized .dash-preview-toggle {
   opacity: 1;
 }
 
@@ -2215,12 +2238,24 @@ body.dash-layout-maximized #dash-task-progress {
 
 /* --- Layout Mode: Fullscreen --- */
 .dash-preview:fullscreen {
-  display: flex;
-  flex-direction: column;
+  position: relative;
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
   background: #000;
+  border: none;
+  border-radius: 0;
+  margin: 0;
 }
 .dash-preview:fullscreen .dash-preview-stage {
-  flex: 1 1 auto;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100% !important;
+  height: 100% !important;
+  flex: none;
   aspect-ratio: auto !important;
   min-height: 0;
 }
@@ -2232,7 +2267,21 @@ body.dash-layout-maximized #dash-task-progress {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 20;
+  z-index: 22;
+}
+.dash-preview:fullscreen .dash-preview-urlbar {
+  position: absolute;
+  top: 42px;
+  left: 12px;
+  right: 12px;
+  z-index: 21;
+  border: 1px solid rgba(255, 241, 232, 0.10);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.26);
+}
+.dash-preview:fullscreen .dash-preview-btn,
+.dash-preview:fullscreen .dash-preview-toggle {
+  opacity: 1;
 }
 
 /* --- Fullscreen Exit Overlay --- */
@@ -2240,7 +2289,7 @@ body.dash-layout-maximized #dash-task-progress {
   position: absolute;
   top: 12px;
   right: 12px;
-  z-index: 20;
+  z-index: 24;
   opacity: 0;
   transition: opacity 300ms ease;
   pointer-events: auto;

--- a/showcase/angular/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/showcase/angular/src/app/pages/dashboard/dashboard-page.component.ts
@@ -809,7 +809,13 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
 
     // Fullscreen change
     this.listen(document, 'fullscreenchange', () => {
-      if (!document.fullscreenElement && this.previewLayoutMode === 'fullscreen') {
+      if (document.fullscreenElement === this.previewContainer) {
+        if (this.previewLayoutMode !== 'fullscreen') {
+          this.setPreviewLayout('fullscreen');
+        } else if (this.previewState === 'streaming') {
+          this.updatePreviewScale();
+        }
+      } else if (!document.fullscreenElement && this.previewLayoutMode === 'fullscreen') {
         this.setPreviewLayout('inline');
       }
     });
@@ -2868,6 +2874,29 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
     return typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches;
   }
 
+  private isScreenPreviewLayout(): boolean {
+    return this.previewLayoutMode === 'maximized' || this.previewLayoutMode === 'fullscreen';
+  }
+
+  private getScreenPreviewStageSize(): { width: number; height: number } {
+    const rect = this.previewContainer?.getBoundingClientRect();
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 1;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 1;
+    return {
+      width: Math.max(1, Math.round(rect?.width || viewportWidth)),
+      height: Math.max(1, Math.round(rect?.height || viewportHeight)),
+    };
+  }
+
+  private resetPreviewContainerFrame(): void {
+    if (!this.previewContainer) return;
+    this.previewContainer.style.left = '';
+    this.previewContainer.style.top = '';
+    this.previewContainer.style.bottom = '';
+    this.previewContainer.style.right = '';
+    this.previewContainer.style.height = '';
+  }
+
   private handleDOMSnapshot(payload: any): void {
     if (!payload || !payload.html) {
       this.recordTransportError('dom-snapshot-invalid', 'DOM snapshot missing html payload', { type: 'ext:dom-snapshot' });
@@ -2944,7 +2973,7 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
     if (!this.previewIframe || !this.previewContainer || !this.previewStage || !this.previewSnapshotData) return;
     const pageWidth = Math.max(1, this.previewSnapshotData.viewportWidth || this.previewSnapshotData.pageWidth || 1920);
     const pageHeight = Math.max(1, this.previewSnapshotData.viewportHeight || 1080);
-    const stageWidth = Math.max(1, this.previewStage.clientWidth || this.previewContainer.clientWidth || 1);
+    let stageWidth = Math.max(1, this.previewStage.clientWidth || this.previewContainer.clientWidth || 1);
     let stageHeight = Math.max(1, this.previewStage.clientHeight || Math.round(stageWidth * 10 / 16));
 
     if (this.previewLayoutMode === 'inline' || this.previewLayoutMode === 'pip') {
@@ -2952,9 +2981,17 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
       const computedHeight = fixedStageRatio
         ? Math.round(stageWidth * 10 / 16)
         : Math.max(200, Math.min(Math.round((pageHeight / pageWidth) * stageWidth), window.innerHeight * 0.9));
+      this.previewStage.style.width = '';
       this.previewStage.style.height = computedHeight + 'px';
       stageHeight = computedHeight;
+    } else if (this.isScreenPreviewLayout()) {
+      const screenStage = this.getScreenPreviewStageSize();
+      this.previewStage.style.width = screenStage.width + 'px';
+      this.previewStage.style.height = screenStage.height + 'px';
+      stageWidth = screenStage.width;
+      stageHeight = screenStage.height;
     } else {
+      this.previewStage.style.width = '';
       this.previewStage.style.height = '';
       stageHeight = Math.max(1, this.previewStage.clientHeight || stageHeight);
     }
@@ -3019,6 +3056,7 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
 
     switch (mode) {
       case 'maximized':
+        this.resetPreviewContainerFrame();
         if (this.previewContainer) this.previewContainer.classList.add('dash-preview-maximized');
         document.body.classList.add('dash-layout-maximized');
         if (this.previewMaximizeBtn) { this.previewMaximizeBtn.innerHTML = '<i class="fa-solid fa-compress"></i>'; this.previewMaximizeBtn.title = 'Minimize'; }
@@ -3028,6 +3066,7 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
         if (this.previewPipBtn) { this.previewPipBtn.innerHTML = '<i class="fa-solid fa-arrow-down-left-and-up-right-to-center"></i>'; this.previewPipBtn.title = 'Exit picture-in-picture'; }
         break;
       case 'fullscreen':
+        this.resetPreviewContainerFrame();
         if (this.previewFsExit) this.previewFsExit.style.display = 'block';
         if (this.previewFullscreenBtn) { this.previewFullscreenBtn.innerHTML = '<i class="fa-solid fa-down-left-and-up-right-to-center"></i>'; this.previewFullscreenBtn.title = 'Exit fullscreen'; }
         break;
@@ -3037,13 +3076,7 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
         if (this.previewPipBtn) { this.previewPipBtn.innerHTML = '<i class="fa-solid fa-window-restore"></i>'; this.previewPipBtn.title = 'Picture-in-picture'; }
         if (this.previewFullscreenBtn) { this.previewFullscreenBtn.innerHTML = '<i class="fa-solid fa-up-right-and-down-left-from-center"></i>'; this.previewFullscreenBtn.title = 'Fullscreen'; }
         if (this.previewFsExit) this.previewFsExit.style.display = 'none';
-        if (this.previewContainer) {
-          this.previewContainer.style.left = '';
-          this.previewContainer.style.top = '';
-          this.previewContainer.style.bottom = '';
-          this.previewContainer.style.right = '';
-          this.previewContainer.style.height = '';
-        }
+        this.resetPreviewContainerFrame();
         break;
     }
     setTimeout(() => this.updatePreviewScale(), 50);
@@ -3061,8 +3094,9 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
     if (document.fullscreenElement === this.previewContainer) {
       document.exitFullscreen();
     } else if (this.previewContainer) {
-      this.previewContainer.requestFullscreen().catch(() => {});
-      this.setPreviewLayout('fullscreen');
+      this.previewContainer.requestFullscreen()
+        .then(() => this.setPreviewLayout('fullscreen'))
+        .catch(() => {});
     }
   }
 

--- a/showcase/css/dashboard.css
+++ b/showcase/css/dashboard.css
@@ -2260,22 +2260,46 @@
 .dash-preview-maximized {
   position: fixed !important;
   inset: 0 !important;
-  display: flex !important;
-  flex-direction: column !important;
+  display: block !important;
   z-index: 100 !important;
+  aspect-ratio: auto !important;
   min-height: 100vh !important;
+  height: 100vh !important;
+  height: 100dvh !important;
   border-radius: 0 !important;
   margin: 0 !important;
   border: none !important;
+  background: #000 !important;
 }
 
 .dash-preview-maximized .dash-preview-stage {
-  flex: 1 1 auto;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100% !important;
+  height: 100% !important;
+  flex: none;
   aspect-ratio: auto !important;
   min-height: 0;
 }
 
-.dash-preview-maximized .dash-preview-btn {
+.dash-preview-maximized .dash-preview-header {
+  z-index: 22;
+}
+
+.dash-preview-maximized .dash-preview-urlbar {
+  position: absolute;
+  top: 42px;
+  left: 12px;
+  right: 12px;
+  z-index: 21;
+  border: 1px solid rgba(255, 241, 232, 0.10);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.26);
+}
+
+.dash-preview-maximized .dash-preview-btn,
+.dash-preview-maximized .dash-preview-toggle {
   opacity: 1;
 }
 
@@ -2320,12 +2344,24 @@ body.dash-layout-maximized #dash-task-progress {
 
 /* --- Layout Mode: Fullscreen --- */
 .dash-preview:fullscreen {
-  display: flex;
-  flex-direction: column;
+  position: relative;
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
   background: #000;
+  border: none;
+  border-radius: 0;
+  margin: 0;
 }
 .dash-preview:fullscreen .dash-preview-stage {
-  flex: 1 1 auto;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100% !important;
+  height: 100% !important;
+  flex: none;
   aspect-ratio: auto !important;
   min-height: 0;
 }
@@ -2337,7 +2373,21 @@ body.dash-layout-maximized #dash-task-progress {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 20;
+  z-index: 22;
+}
+.dash-preview:fullscreen .dash-preview-urlbar {
+  position: absolute;
+  top: 42px;
+  left: 12px;
+  right: 12px;
+  z-index: 21;
+  border: 1px solid rgba(255, 241, 232, 0.10);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.26);
+}
+.dash-preview:fullscreen .dash-preview-btn,
+.dash-preview:fullscreen .dash-preview-toggle {
+  opacity: 1;
 }
 
 /* --- Fullscreen Exit Overlay --- */
@@ -2345,7 +2395,7 @@ body.dash-layout-maximized #dash-task-progress {
   position: absolute;
   top: 12px;
   right: 12px;
-  z-index: 20;
+  z-index: 24;
   opacity: 0;
   transition: opacity 300ms ease;
   pointer-events: auto;

--- a/showcase/js/dashboard.js
+++ b/showcase/js/dashboard.js
@@ -2697,6 +2697,29 @@
     return window.matchMedia && window.matchMedia('(max-width: 768px)').matches;
   }
 
+  function isScreenPreviewLayout() {
+    return previewLayoutMode === 'maximized' || previewLayoutMode === 'fullscreen';
+  }
+
+  function getScreenPreviewStageSize() {
+    var rect = previewContainer ? previewContainer.getBoundingClientRect() : null;
+    var viewportWidth = window.innerWidth || document.documentElement.clientWidth || 1;
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight || 1;
+    return {
+      width: Math.max(1, Math.round((rect && rect.width) || viewportWidth)),
+      height: Math.max(1, Math.round((rect && rect.height) || viewportHeight))
+    };
+  }
+
+  function resetPreviewContainerFrame() {
+    if (!previewContainer) return;
+    previewContainer.style.left = '';
+    previewContainer.style.top = '';
+    previewContainer.style.bottom = '';
+    previewContainer.style.right = '';
+    previewContainer.style.height = '';
+  }
+
   function handleDOMSnapshot(payload) {
     if (!payload || !payload.html) {
       recordDashboardTransportError('dom-snapshot-invalid', 'DOM snapshot missing html payload', {
@@ -2818,9 +2841,17 @@
       var computedHeight = fixedStageRatio
         ? Math.round(stageWidth * 10 / 16)
         : Math.max(200, Math.min(Math.round((pageHeight / pageWidth) * stageWidth), window.innerHeight * 0.9));
+      previewStage.style.width = '';
       previewStage.style.height = computedHeight + 'px';
       stageHeight = computedHeight;
+    } else if (isScreenPreviewLayout()) {
+      var screenStage = getScreenPreviewStageSize();
+      previewStage.style.width = screenStage.width + 'px';
+      previewStage.style.height = screenStage.height + 'px';
+      stageWidth = screenStage.width;
+      stageHeight = screenStage.height;
     } else {
+      previewStage.style.width = '';
       previewStage.style.height = '';
       stageHeight = Math.max(1, previewStage.clientHeight || stageHeight);
     }
@@ -2895,6 +2926,7 @@
 
     switch (mode) {
       case 'maximized':
+        resetPreviewContainerFrame();
         if (previewContainer) previewContainer.classList.add('dash-preview-maximized');
         document.body.classList.add('dash-layout-maximized');
         if (previewMaximizeBtn) previewMaximizeBtn.innerHTML = '<i class="fa-solid fa-compress"></i>';
@@ -2908,6 +2940,7 @@
         break;
 
       case 'fullscreen':
+        resetPreviewContainerFrame();
         if (previewFsExit) previewFsExit.style.display = 'block';
         if (previewFullscreenBtn) previewFullscreenBtn.innerHTML = '<i class="fa-solid fa-down-left-and-up-right-to-center"></i>';
         if (previewFullscreenBtn) previewFullscreenBtn.title = 'Exit fullscreen';
@@ -2923,14 +2956,7 @@
         if (previewFullscreenBtn) previewFullscreenBtn.innerHTML = '<i class="fa-solid fa-up-right-and-down-left-from-center"></i>';
         if (previewFullscreenBtn) previewFullscreenBtn.title = 'Fullscreen';
         if (previewFsExit) previewFsExit.style.display = 'none';
-        // Reset PiP drag positioning
-        if (previewContainer) {
-          previewContainer.style.left = '';
-          previewContainer.style.top = '';
-          previewContainer.style.bottom = '';
-          previewContainer.style.right = '';
-          previewContainer.style.height = '';
-        }
+        resetPreviewContainerFrame();
         break;
     }
 
@@ -2959,16 +2985,23 @@
     if (document.fullscreenElement === previewContainer) {
       document.exitFullscreen();
     } else if (previewContainer) {
-      previewContainer.requestFullscreen().catch(function(err) {
-        console.warn('[FSB-DASH] Fullscreen request failed:', err.message);
-      });
-      setPreviewLayout('fullscreen');
+      previewContainer.requestFullscreen()
+        .then(function() { setPreviewLayout('fullscreen'); })
+        .catch(function(err) {
+          console.warn('[FSB-DASH] Fullscreen request failed:', err.message);
+        });
     }
   }
 
   // Exit fullscreen when user presses Escape or browser exits fullscreen
   document.addEventListener('fullscreenchange', function() {
-    if (!document.fullscreenElement && previewLayoutMode === 'fullscreen') {
+    if (document.fullscreenElement === previewContainer) {
+      if (previewLayoutMode !== 'fullscreen') {
+        setPreviewLayout('fullscreen');
+      } else if (previewState === 'streaming') {
+        updatePreviewScale();
+      }
+    } else if (!document.fullscreenElement && previewLayoutMode === 'fullscreen') {
       setPreviewLayout('inline');
     }
   });

--- a/tests/dashboard-preview-aspect-ratio.test.js
+++ b/tests/dashboard-preview-aspect-ratio.test.js
@@ -1,6 +1,7 @@
 /**
  * Phase 280/281 VIEWPORT regression: dashboard stream stage must hold 16:10
- * on desktop, unset on mobile, unset in Maximized mode, and 16:10 in PiP.
+ * on desktop, unset on mobile, fill the viewer surface in Maximized/Fullscreen,
+ * and 16:10 in PiP.
  *
  * Run: node tests/dashboard-preview-aspect-ratio.test.js
  */
@@ -143,6 +144,43 @@ assert(maximizedBlock !== null, '.dash-preview-maximized block exists');
 assert(
   maximizedBlock && /aspect-ratio:\s*auto\s*!important/.test(maximizedBlock),
   'Maximized layout overrides aspect-ratio: auto !important (so 100vh fills the screen)'
+);
+
+const maximizedStageBlock = extractBlock(scss, /\.dash-preview-maximized\s+\.dash-preview-stage\s*\{/);
+assert(maximizedStageBlock !== null, '.dash-preview-maximized .dash-preview-stage block exists');
+assert(
+  maximizedStageBlock && /position:\s*absolute/.test(maximizedStageBlock) &&
+    /inset:\s*0/.test(maximizedStageBlock) &&
+    /width:\s*100%\s*!important/.test(maximizedStageBlock) &&
+    /height:\s*100%\s*!important/.test(maximizedStageBlock),
+  'Maximized stream stage fills the viewer surface'
+);
+
+const fullscreenStageBlock = extractBlock(scss, /\.dash-preview:fullscreen\s+\.dash-preview-stage\s*\{/);
+assert(fullscreenStageBlock !== null, '.dash-preview:fullscreen .dash-preview-stage block exists');
+assert(
+  fullscreenStageBlock && /position:\s*absolute/.test(fullscreenStageBlock) &&
+    /inset:\s*0/.test(fullscreenStageBlock) &&
+    /width:\s*100%\s*!important/.test(fullscreenStageBlock) &&
+    /height:\s*100%\s*!important/.test(fullscreenStageBlock),
+  'Fullscreen stream stage fills the actual fullscreen surface'
+);
+
+const fullscreenUrlbarBlock = extractBlock(scss, /\.dash-preview:fullscreen\s+\.dash-preview-urlbar\s*\{/);
+assert(fullscreenUrlbarBlock !== null, '.dash-preview:fullscreen .dash-preview-urlbar block exists');
+assert(
+  fullscreenUrlbarBlock && /position:\s*absolute/.test(fullscreenUrlbarBlock) &&
+    /z-index:\s*21/.test(fullscreenUrlbarBlock),
+  'Fullscreen keeps the existing URL bar as an overlay above the stream stage'
+);
+
+const vanillaFullscreenStageBlock = extractBlock(css, /\.dash-preview:fullscreen\s+\.dash-preview-stage\s*\{/);
+assert(vanillaFullscreenStageBlock !== null, 'vanilla fullscreen stage block exists');
+assert(
+  vanillaFullscreenStageBlock && /position:\s*absolute/.test(vanillaFullscreenStageBlock) &&
+    /width:\s*100%\s*!important/.test(vanillaFullscreenStageBlock) &&
+    /height:\s*100%\s*!important/.test(vanillaFullscreenStageBlock),
+  'vanilla fullscreen stream stage fills the viewer surface'
 );
 
 const pipStageBlock = extractBlock(scss, /\.dash-preview-pip\s+\.dash-preview-stage\s*\{/);

--- a/tests/dashboard-preview-fit.test.js
+++ b/tests/dashboard-preview-fit.test.js
@@ -64,6 +64,11 @@ near(metrics.scale, 1000 / 1600, 'tall scale uses height fit');
 near(metrics.offsetX, 518.75, 'tall pillarbox offsetX');
 near(metrics.offsetY, 0, 'tall offsetY');
 
+metrics = fit(1600, 1000, 1920, 1080);
+near(metrics.scale, 1080 / 1000, 'fullscreen 16:9 screen uses viewer height fit');
+near(metrics.offsetX, 96, 'fullscreen 16:9 screen pillarboxes 16:10 source');
+near(metrics.offsetY, 0, 'fullscreen 16:9 screen offsetY');
+
 console.log('--- remote coordinate mapping ---');
 
 metrics = fit(1920, 1080, 1600, 1000);
@@ -96,6 +101,12 @@ assert(/previewOffsetX/.test(TS) && /previewOffsetY/.test(TS), 'Angular stores p
 assert(/previewOffsetX/.test(JS) && /previewOffsetY/.test(JS), 'vanilla dashboard stores preview offsets');
 assert(/Math\.min\(stageWidth \/ pageWidth,\s*stageHeight \/ pageHeight\)/.test(TS), 'Angular uses uniform fit scale');
 assert(/Math\.min\(stageWidth \/ pageWidth,\s*stageHeight \/ pageHeight\)/.test(JS), 'vanilla dashboard uses uniform fit scale');
+assert(/isScreenPreviewLayout\(\)/.test(TS) && /getScreenPreviewStageSize\(\)/.test(TS), 'Angular has screen-layout sizing helpers');
+assert(/isScreenPreviewLayout\(\)/.test(JS) && /getScreenPreviewStageSize\(\)/.test(JS), 'vanilla dashboard has screen-layout sizing helpers');
+assert(/this\.previewStage\.style\.width = screenStage\.width \+ 'px'/.test(TS), 'Angular pins screen-mode stage width to viewer surface');
+assert(/previewStage\.style\.width = screenStage\.width \+ 'px'/.test(JS), 'vanilla pins screen-mode stage width to viewer surface');
+assert(/document\.fullscreenElement === this\.previewContainer/.test(TS), 'Angular recalculates on fullscreen entry');
+assert(/document\.fullscreenElement === previewContainer/.test(JS), 'vanilla recalculates on fullscreen entry');
 assert(/\(localX - this\.previewOffsetX\) \/ scale/.test(TS), 'Angular remote X subtracts letterbox offset');
 assert(/\(localX - previewOffsetX\) \/ scale/.test(JS), 'vanilla remote X subtracts letterbox offset');
 assert(/this\.previewOffsetX \+ payload\.glow\.x \* this\.previewScale/.test(TS), 'Angular glow X adds letterbox offset');


### PR DESCRIPTION
## Summary

- keep the normal dashboard stream preview and PiP at 16:10
- make maximized and browser fullscreen preview stages fill the viewer surface instead of inheriting the streamed tab aspect
- float the existing dashboard header and URL bar above the full-screen stream without changing the visual theme
- preserve uniform stream fit math so the iframe letterboxes/pillarboxes rather than stretching
- keep remote-control coordinate and glow overlay mapping aligned with the fitted stream offsets

## Validation

- `npx -y -p node@20 -p npm@10 sh -c 'node -v && npm -v && npm --prefix showcase/server rebuild better-sqlite3 && npm run ci'`
- `git diff --check`

Note: local Node 24 could not load the ignored `better-sqlite3` native module because of macOS code-signing metadata, so the full local run used Node 20 to match GitHub Actions.