### PR TITLE
[codex] fix sync remote control relay pairing

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -10,7 +10,7 @@ FSB is an AI-powered browser automation Chrome extension that executes tasks thr
 
 ## Current State
 
-**Last shipped:** v0.9.69 Anonymous Telemetry Pipeline + Showcase Dashboard Streaming Fix -- 2026-05-14. 8 phases (269-276), 9 plans, 67/68 v0.9.69 REQs Complete (STREAM-03 Partial / `human_needed` by design per locked D-16; defensive Phase-276 patches were attempt 1 of the STREAM-07 5-attempt cap — actual repro confirmation deferred to v0.9.70). Anonymous UUIDv4 install identity + opt-out kill-switch; MCP pricing module + cost-surfacing chokepoint at both dispatch routes; TelemetryCollector 5-min alarm beat surviving MV3 SW eviction; SQLite ingest with 8-layer abuse defenses, HMAC-SHA256 daily-rotated IP hashing, k>=2 anonymity floor (lowered from 5 in post-milestone fix to surface client labels at single-digit install counts); `/api/public-stats/global` + `/global/series` aggregates rendered as 6 new chart toggles on `/stats` Easter-egg page; privacy disclosure section + CWS listing copy + `verify-store-listing.mjs` gate; server-side GitHub stats cache to keep visitor browsers off the 60-req/hr unauth rate limit (5-min poller backed by SQLite `github_cache` table); MCP transport `z.coerce.number()` fix so MCP clients can pass tabId/tab_id as either string or number. All 3 release-gating BLOCKERs RESOLVED. Released artifacts: extension v0.9.67 zip on GitHub, mcp-v0.9.2 auto-published to npm, Fly auto-deployed.
+**Last shipped:** v0.9.70 streaming/viewport slice -- 2026-05-18. Dashboard DOM streaming now reaches the showcase preview after the canonical content bundle injects `content/dom-stream.js`; the preview pane is fixed at 16:10 for inline desktop/PiP; maximized and browser-fullscreen modes fit the actual viewer surface without stretching the streamed DOM. PR #73 merged and Fly deployment passed. Earlier v0.9.69 shipped the anonymous telemetry pipeline, public `/stats` aggregates, privacy/CWS disclosure guard, server-side GitHub stats cache, MCP numeric-parameter coercion, extension v0.9.67 zip, and `fsb-mcp-server@0.9.2`.
 
 **Recent shipping cadence:**
 - v0.9.69 Anonymous Telemetry Pipeline + Showcase Dashboard Streaming Fix -- shipped 2026-05-14
@@ -33,13 +33,13 @@ FSB is an AI-powered browser automation Chrome extension that executes tasks thr
 **Goal:** Make the showcase dashboard preview pane actually work — diagnose and fix the broken DOM-streaming pipeline, restore the broken Sync-tab remote-control flow, and lock the preview pane to a fixed 16:10 desktop viewport.
 
 **Target features:**
-- **Dashboard DOM-streaming fix.** Reproduce the `dash:dom-stream-*` break in a live browser to validate or invalidate the four unfired hypotheses (#3, #5, #6, #7) from v0.9.69 Phase 276. If a single hypothesis is the root cause, ship the minimum patch. If the architecture is the root cause, escalate to a rewrite of the dom-stream transport within this milestone (this counts as attempt 2 of the STREAM-07 5-attempt cap).
-- **Sync tab remote control fix.** Investigate why the showcase dashboard "Sync" tab (the v0.9.45rc1 remote-from-website pairing surface that pairs a browser session to an extension install) is currently broken; restore pairing + remote-command dispatch end-to-end on `full-selfbrowsing.com`.
-- **16:10 desktop viewport for preview pane.** Lock the showcase dashboard preview pane (the dom-stream viewport surface) to a fixed 16:10 aspect ratio on desktop screens regardless of source viewport. Mobile layout intentionally untouched.
+- **Dashboard DOM-streaming fix. COMPLETE.** Root cause was the canonical content-script bundle missing `content/dom-stream.js`, so the source tab never registered the `pingDomStream` readiness handler. The merged fix injects the module and the user verified live streaming works.
+- **Preview viewport fit. COMPLETE.** Inline desktop and PiP preview surfaces are fixed at 16:10. Maximized and browser-fullscreen modes now size to the actual viewer surface and preserve DOM scale without stretching. Mobile layout remains intentionally untouched.
+- **Sync tab remote control fix. ACTIVE.** Investigate why the showcase dashboard "Sync" tab (the v0.9.45rc1 remote-from-website pairing surface that pairs a browser session to an extension install) is currently broken; restore pairing + remote-command dispatch end-to-end on `full-selfbrowsing.com`.
 
 **Key constraints:**
-- Diagnose-first on the stream fix: no patch lands without a browser-confirmed hypothesis. STREAM-07 from v0.9.69 (5-attempt cap) governs escalation budget; defensive Phase-276 patches were attempt 1.
-- Mobile dashboard layout out of scope for the aspect-ratio work — desktop-only fix.
+- Streaming and viewport fixes are closed unless regression testing proves otherwise; do not reopen them while working the Sync-tab fix.
+- Mobile dashboard layout remains out of scope for the already-shipped aspect-ratio work.
 - Carry-forward telemetry-follow-up backlog (sparklines, first-run banner, "View what we send", region-gated opt-in, public API docs, geo heatmap) **deferred again** — not in this milestone.
 - Carry-forward v0.9.64 (picker-cookie short-circuit) and v0.9.65 (dashboard i18n) also **deferred again**.
 - Server-side extension where needed continues to extend `showcase/server/` (Express + SQLite); no new microservice.

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,3 +1,36 @@
+# Active Milestone v0.9.70 Requirements
+
+**Milestone:** v0.9.70 Showcase Dashboard Reliability (Streaming + Sync + Viewport)
+**Status:** Streaming and viewport requirements complete as of 2026-05-18; Sync remote-control restoration active.
+
+## v0.9.70 Requirements
+
+### Dashboard Streaming -- STREAM70
+
+- [x] **STREAM70-01:** Dashboard DOM streaming starts on a normal source tab after the extension is reloaded/sideloaded -- canonical content-script injection includes `content/dom-stream.js`, so `pingDomStream` is registered in the source tab.
+- [x] **STREAM70-02:** Dashboard stream candidate selection no longer reports the dashboard tab itself as the only restricted candidate when a streamable source tab exists.
+- [x] **STREAM70-03:** Runtime tests exercise behavior, not static identifier presence, for the DOM stream readiness path.
+- [x] **STREAM70-04:** User verified the deployed dashboard stream works live after PR #73 deployment.
+
+### Dashboard Viewport Fit -- VIEW70
+
+- [x] **VIEW70-01:** Desktop inline preview uses a fixed 16:10 viewport surface.
+- [x] **VIEW70-02:** PiP preview preserves 16:10 without resizing jitter.
+- [x] **VIEW70-03:** Maximized mode sizes to the actual dashboard viewer surface while preserving DOM scale.
+- [x] **VIEW70-04:** Browser fullscreen mode sizes to the actual fullscreen viewport while preserving DOM scale.
+- [x] **VIEW70-05:** Mobile dashboard layout remains untouched.
+
+### Sync Remote Control -- SYNC70
+
+- [ ] **SYNC70-01:** A user can open the showcase dashboard Sync tab and create or refresh a pairing session.
+- [ ] **SYNC70-02:** The extension can join the same pairing session from the Sync tab / remote-control surface.
+- [ ] **SYNC70-03:** A remote command sent from `full-selfbrowsing.com` reaches the paired extension session exactly once.
+- [ ] **SYNC70-04:** The extension acknowledges success/failure back to the dashboard, and the dashboard renders the current paired/ready state accurately.
+- [ ] **SYNC70-05:** Stale, expired, or mismatched pairing sessions fail visibly without breaking streaming or dashboard reconnect.
+- [ ] **SYNC70-06:** Regression coverage protects the fixed pairing and remote-command dispatch path.
+
+---
+
 # Milestone v0.9.69 Requirements
 
 **Milestone:** v0.9.69 Anonymous Telemetry Pipeline + Showcase Dashboard Streaming Fix

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,5 +1,27 @@
 # Roadmap
 
+**Active supplement (2026-05-18):** v0.9.70 Showcase Dashboard Reliability (Streaming + Sync + Viewport) is now the active milestone. The historical v0.9.69 roadmap remains below for archive continuity until the next full GSD roadmap regeneration.
+
+## Active Milestone: v0.9.70 (Phases 277-279)
+
+**Goal:** Make the showcase dashboard reliable for live preview and remote control: streaming works, preview sizing is correct, and Sync-tab pairing can dispatch remote commands end-to-end.
+
+## v0.9.70 Phases
+
+- [x] **Phase 277: Dashboard DOM-Stream Runtime Restoration** -- canonical content-script bundle injects `content/dom-stream.js`; source tabs register `pingDomStream`; user verified dashboard streaming works live after reload/sideload. Completed 2026-05-18.
+- [x] **Phase 278: Dashboard Preview Viewport Fit** -- inline desktop/PiP preview fixed to 16:10; maximized and browser-fullscreen modes fit the actual viewer surface without stretching the streamed DOM. PR #73 merged and deployed 2026-05-18.
+- [ ] **Phase 279: Sync Tab Remote-Control Restoration** -- diagnose the current Sync-tab pairing / remote-command dispatch break; restore website-to-extension remote control on `full-selfbrowsing.com` with regression coverage.
+
+## v0.9.70 Progress
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 277. Dashboard DOM-Stream Runtime Restoration | 1/1 | Complete | 2026-05-18 |
+| 278. Dashboard Preview Viewport Fit | 1/1 | Complete | 2026-05-18 |
+| 279. Sync Tab Remote-Control Restoration | 0/1 | Active | -- |
+
+---
+
 **Status:** v0.9.69 Anonymous Telemetry Pipeline + Showcase Dashboard Streaming Fix -- scoped 2026-05-14, roadmap approved, awaiting Phase 269 plan.
 
 **Branch posture:** v0.9.69 work continues on `Refinements` (already 6 commits ahead of `origin/main` from quick task 260514-1nv plus version bump). The milestone-close PR merges `Refinements` -> `main`. Deploy targets remain showcase Angular + Express on Fly.io at `https://full-selfbrowsing.com`.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,34 +3,34 @@ gsd_state_version: 1.0
 milestone: v0.9.70
 milestone_name: Showcase Dashboard Reliability (Streaming + Sync + Viewport)
 status: in_progress
-last_updated: "2026-05-16T00:00:00.000Z"
-last_activity: "2026-05-16 -- milestone v0.9.70 started; PROJECT.md + STATE.md updated; awaiting REQUIREMENTS.md + ROADMAP.md per new-milestone workflow"
+last_updated: "2026-05-18T00:00:00.000Z"
+last_activity: "2026-05-18 -- streaming and viewport slices marked complete after merged/deployed fixes; Sync-tab remote-control restoration is now active"
 progress:
-  total_phases: 0
-  completed_phases: 0
-  total_plans: 0
-  completed_plans: 0
-  percent: 0
+  total_phases: 3
+  completed_phases: 2
+  total_plans: 3
+  completed_plans: 2
+  percent: 67
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-05-16 -- v0.9.70 started)
+See: .planning/PROJECT.md (updated 2026-05-18 -- streaming/viewport complete; Sync remote control active)
 See: .planning/MILESTONES.md (v0.9.69 shipped 2026-05-14; v0.9.70 in flight)
-See: .planning/ROADMAP.md (v0.9.70 roadmap pending)
-See: .planning/REQUIREMENTS.md (v0.9.70 requirements pending)
+See: .planning/ROADMAP.md (v0.9.70 active supplement added above archived v0.9.69 roadmap)
+See: .planning/REQUIREMENTS.md (v0.9.70 active supplement added above archived v0.9.69 requirements)
 
 **Core value:** Reliable single-attempt execution -- the AI decides correctly, the mechanics execute precisely.
-**Current focus:** v0.9.70 Showcase Dashboard Reliability (Streaming + Sync + Viewport). Diagnose-first dashboard DOM-streaming fix (continues STREAM-07 attempt 2 of 5 from v0.9.69 Phase 276), Sync-tab remote-control restoration, 16:10 desktop viewport for the dashboard preview pane. Mobile layout out of scope. Deploy target `https://full-selfbrowsing.com` (Fly.io).
+**Current focus:** v0.9.70 Showcase Dashboard Reliability (Streaming + Sync + Viewport). Dashboard DOM streaming and preview viewport fitting are complete and deployed. Active focus is Sync-tab remote-control restoration on `https://full-selfbrowsing.com`. Deploy target remains Fly.io.
 
 ## Current Position
 
-Phase: Not started (defining requirements)
-Plan: --
-Status: Defining requirements
-Last activity: 2026-05-16 -- Milestone v0.9.70 started
+Phase: 279 -- Sync Tab Remote-Control Restoration
+Plan: 279-01 -- diagnose pairing + remote-command dispatch, then minimum patch
+Status: Investigating
+Last activity: 2026-05-18 -- Streaming and viewport fixes closed; moving to Sync remote control
 
 ## Performance Metrics
 
@@ -41,7 +41,8 @@ Last activity: 2026-05-16 -- Milestone v0.9.70 started
 
 ## Active Milestone Carry-Forward (from v0.9.69)
 
-- **STREAM-07 (Phase 276):** defensive patches landed as attempt 1 of the 5-attempt cap; browser repro confirmation never executed. v0.9.70 begins attempt 2 — diagnose-first, then minimum patch OR transport rewrite if a single hypothesis cannot explain the symptom.
+- **Streaming carry-forward CLOSED:** Phase 276 defensive work was followed by v0.9.70 fixes for content-script DOM stream injection, 16:10 desktop preview fit, and fullscreen actual-screen fit. User verified live streaming works after PR #73 deploy.
+- **Active remote-control carry-forward:** Sync-tab pairing / remote-command dispatch remains broken and is the only active v0.9.70 reliability item.
 - **CWS Developer Dashboard click-through (BLOCKER B3 follow-up):** in-repo CI guard shipped in v0.9.69 Phase 275; the manual dashboard click-through remains user-gated per D-15 (8-step checklist in `.planning/milestones/v0.9.69/phases/275-…/275-VERIFICATION.md`).
 
 ## Deferred Items

--- a/extension/background.js
+++ b/extension/background.js
@@ -2142,6 +2142,12 @@ var _lastDomStreamStaleFlushCount = 0;
 // remains untouched at its original name.
 let _bgRemoteControlStateCache = null;
 
+function normalizeDashboardServerUrlForSync(value) {
+  const fallback = 'https://full-selfbrowsing.com';
+  const url = (typeof value === 'string' && value.trim()) ? value.trim() : fallback;
+  return url.replace(/\/+$/, '');
+}
+
 // Store for AI integration instances per session (for multi-turn conversations)
 // This allows conversation history to persist across iterations within a session
 let sessionAIInstances = new Map();
@@ -5370,6 +5376,20 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         _bgRemoteControlStateCache = request.state;
       }
       sendResponse({ success: true });
+      break;
+    }
+
+    case 'reconnectDashboardWebSocket': {
+      try {
+        if (typeof fsbWebSocket !== 'undefined' && fsbWebSocket && typeof fsbWebSocket.connect === 'function') {
+          fsbWebSocket.connect();
+          sendResponse({ success: true });
+        } else {
+          sendResponse({ success: false, error: 'dashboard relay unavailable' });
+        }
+      } catch (error) {
+        sendResponse({ success: false, error: error && error.message ? error.message : 'reconnect failed' });
+      }
       break;
     }
 
@@ -13237,6 +13257,34 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
       fsbWebSocket.connect();
     } else {
       fsbWebSocket.disconnect();
+    }
+  }
+
+  // React to Sync tab server/key changes. Pairing tokens are generated for a
+  // specific hash key; if the relay remains connected to an older key, the
+  // dashboard joins one room while the extension stays in another.
+  if (namespace === 'local' && (changes.serverHashKey || changes.serverUrl)) {
+    const nextKey = changes.serverHashKey
+      ? changes.serverHashKey.newValue
+      : (typeof fsbWebSocket !== 'undefined' && fsbWebSocket ? fsbWebSocket.serverHashKey : null);
+    const nextUrl = changes.serverUrl
+      ? normalizeDashboardServerUrlForSync(changes.serverUrl.newValue)
+      : (typeof fsbWebSocket !== 'undefined' && fsbWebSocket ? normalizeDashboardServerUrlForSync(fsbWebSocket.serverUrl) : null);
+    const currentKey = (typeof fsbWebSocket !== 'undefined' && fsbWebSocket) ? fsbWebSocket.serverHashKey : null;
+    const currentUrl = (typeof fsbWebSocket !== 'undefined' && fsbWebSocket) ? normalizeDashboardServerUrlForSync(fsbWebSocket.serverUrl) : null;
+    const keyChanged = !!nextKey && nextKey !== currentKey;
+    const urlChanged = !!nextUrl && nextUrl !== currentUrl;
+    if (keyChanged || urlChanged) {
+      chrome.storage.local.get(['serverSyncEnabled']).then(({ serverSyncEnabled }) => {
+        if (serverSyncEnabled === false) return;
+        if (typeof fsbWebSocket !== 'undefined' && fsbWebSocket && typeof fsbWebSocket.connect === 'function') {
+          fsbWebSocket.connect();
+        }
+      }).catch(() => {
+        if (typeof fsbWebSocket !== 'undefined' && fsbWebSocket && typeof fsbWebSocket.connect === 'function') {
+          fsbWebSocket.connect();
+        }
+      });
     }
   }
 

--- a/extension/ui/options.js
+++ b/extension/ui/options.js
@@ -4991,12 +4991,27 @@ async function generateHashKey() {
     if (data.hashKey) {
       document.getElementById('serverHashKey').value = data.hashKey;
       await chrome.storage.local.set({ serverUrl, serverHashKey: data.hashKey });
+      requestDashboardRelayReconnect(serverUrl, data.hashKey);
       showToast('Hash key generated and saved', 'success');
     } else {
       showToast('Failed to generate hash key', 'error');
     }
   } catch (error) {
     showToast('Cannot connect to server: ' + error.message, 'error');
+  }
+}
+
+function requestDashboardRelayReconnect(serverUrl, hashKey) {
+  try {
+    chrome.runtime.sendMessage({
+      action: 'reconnectDashboardWebSocket',
+      serverUrl: serverUrl,
+      serverHashKey: hashKey
+    }, function () {
+      var _ = chrome.runtime.lastError;
+    });
+  } catch (_) {
+    // The storage change listener in background.js is the primary path.
   }
 }
 
@@ -5071,6 +5086,7 @@ async function ensureHashKey(serverUrl) {
   const data = await resp.json();
   if (!data || !data.hashKey) throw new Error('Server did not return a hash key');
   await chrome.storage.local.set({ serverUrl, serverHashKey: data.hashKey });
+  requestDashboardRelayReconnect(serverUrl, data.hashKey);
   const keyInput = document.getElementById('serverHashKey');
   if (keyInput) keyInput.value = data.hashKey;
   return data.hashKey;
@@ -5154,6 +5170,7 @@ async function regeneratePairingToken() {
     const stored = await chrome.storage.local.get(['serverUrl', 'serverHashKey']);
     const serverUrl = (stored.serverUrl || FSB_DEFAULT_SERVER_URL).replace(/\/+$/, '');
     const hashKey = stored.serverHashKey || (await ensureHashKey(serverUrl));
+    requestDashboardRelayReconnect(serverUrl, hashKey);
     const data = await fetchPairingToken(serverUrl, hashKey);
     renderPairingQR(qrCodeEl, data.token, serverUrl);
     startPairingCountdown(data.expiresAt);
@@ -5195,6 +5212,7 @@ async function showPairingQR() {
         return; // abort BEFORE opening overlay
       }
     }
+    requestDashboardRelayReconnect(serverUrl, hashKey);
     const data = await fetchPairingToken(serverUrl, hashKey);
     // Reset countdown DOM state before showing
     countdownEl.classList.remove('pairing-countdown-urgent');

--- a/extension/ws/ws-client.js
+++ b/extension/ws/ws-client.js
@@ -29,6 +29,13 @@ function getCurrentTransportTabId() {
   return null;
 }
 
+function _normalizeFsbServerUrl(value) {
+  var url = (typeof value === 'string' && value.trim())
+    ? value.trim()
+    : FSB_SERVER_URL;
+  return url.replace(/\/+$/, '');
+}
+
 function getFSBTransportDiagnostics() {
   if (!globalThis.__FSBTransportDiagnostics || typeof globalThis.__FSBTransportDiagnostics !== 'object') {
     globalThis.__FSBTransportDiagnostics = {
@@ -731,16 +738,19 @@ class FSBWebSocket {
    * Auto-registers a hash key on first run if none exists.
    */
   async connect() {
-    let { serverHashKey } = await chrome.storage.local.get(['serverHashKey']);
+    let { serverHashKey, serverUrl } = await chrome.storage.local.get(['serverHashKey', 'serverUrl']);
+    var resolvedServerUrl = _normalizeFsbServerUrl(serverUrl);
 
     // Auto-register with the server if no hash key exists
     if (!serverHashKey) {
       try {
-        const resp = await fetch(FSB_SERVER_URL + '/api/auth/register', { method: 'POST' });
+        const resp = await fetch(resolvedServerUrl + '/api/auth/register', { method: 'POST' });
         if (resp.ok) {
           const data = await resp.json();
           serverHashKey = data.hashKey;
-          await chrome.storage.local.set({ serverHashKey });
+          this.serverHashKey = serverHashKey;
+          this.serverUrl = resolvedServerUrl;
+          await chrome.storage.local.set({ serverHashKey, serverUrl: resolvedServerUrl });
           console.log('[FSB WS] Auto-registered with server');
         } else {
           console.warn('[FSB WS] Auto-register failed:', resp.status);
@@ -756,6 +766,7 @@ class FSBWebSocket {
 
     // Phase 223 MET-02: capture for metrics broadcast (truncated to 8 chars when emitted).
     this.serverHashKey = serverHashKey;
+    this.serverUrl = resolvedServerUrl;
 
     // Close any existing connection before opening a new one
     if (this.ws) {
@@ -763,7 +774,7 @@ class FSBWebSocket {
       this.ws = null;
     }
 
-    const wsUrl = FSB_SERVER_URL.replace(/^http/, 'ws') + '/ws?key=' + encodeURIComponent(serverHashKey) + '&role=extension';
+    const wsUrl = resolvedServerUrl.replace(/^http/, 'ws') + '/ws?key=' + encodeURIComponent(serverHashKey) + '&role=extension';
 
     this.intentionalClose = false;
 

--- a/showcase/angular/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/showcase/angular/src/app/pages/dashboard/dashboard-page.component.ts
@@ -86,22 +86,68 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
 
   ngOnInit(): void {
     this.meta.updateTag({ name: 'robots', content: 'noindex, nofollow' });
-    this.loadDashboardCdnScripts();
+    void this.loadDashboardCdnScripts();
   }
 
-  private loadDashboardCdnScripts(): void {
-    const libs: ReadonlyArray<readonly [string, string]> = [
-      ['dash-html5-qrcode', 'https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js'],
-      ['dash-lz-string',    'https://unpkg.com/lz-string@1.5.0/libs/lz-string.min.js'],
-    ];
-    for (const [id, src] of libs) {
-      if (this.doc.head.querySelector(`script[data-cdn="${id}"]`)) continue;
-      const s = this.renderer.createElement('script') as HTMLScriptElement;
-      this.renderer.setAttribute(s, 'src', src);
-      this.renderer.setAttribute(s, 'data-cdn', id);
-      this.renderer.setAttribute(s, 'defer', '');
-      this.renderer.appendChild(this.doc.body, s);
-    }
+  private loadDashboardCdnScripts(): Promise<void> {
+    return Promise.all([
+      this.ensureDashboardScript('dash-html5-qrcode', this.HTML5_QRCODE_SRC, 'Html5Qrcode'),
+      this.ensureDashboardScript('dash-lz-string', this.LZ_STRING_SRC, 'LZString'),
+    ]).then(() => undefined);
+  }
+
+  private ensureDashboardScript(id: string, src: string, globalName: string): Promise<void> {
+    const w = window as any;
+    if (w[globalName]) return Promise.resolve();
+
+    const existingPromise = this.dashboardScriptPromises.get(id);
+    if (existingPromise) return existingPromise;
+
+    const selector = `script[data-cdn="${id}"]`;
+    let script = this.doc.body.querySelector(selector) as HTMLScriptElement | null;
+    if (!script) script = this.doc.head.querySelector(selector) as HTMLScriptElement | null;
+
+    const promise = new Promise<void>((resolve, reject) => {
+      function cleanup() {
+        script?.removeEventListener('load', finish);
+        script?.removeEventListener('error', fail);
+      }
+      function finish() {
+        cleanup();
+        if (w[globalName]) {
+          script?.setAttribute('data-loaded', 'true');
+          resolve();
+        } else {
+          reject(new Error(globalName + ' did not initialize'));
+        }
+      }
+      function fail() {
+        cleanup();
+        reject(new Error('Failed to load ' + globalName));
+      }
+
+      if (script?.getAttribute('data-loaded') === 'true') {
+        finish();
+        return;
+      }
+
+      if (!script) {
+        script = this.renderer.createElement('script') as HTMLScriptElement;
+        this.renderer.setAttribute(script, 'src', src);
+        this.renderer.setAttribute(script, 'data-cdn', id);
+        this.renderer.setAttribute(script, 'async', 'true');
+        script.addEventListener('load', finish);
+        script.addEventListener('error', fail);
+        this.renderer.appendChild(this.doc.body, script);
+        return;
+      }
+
+      script.addEventListener('load', finish);
+      script.addEventListener('error', fail);
+    });
+
+    this.dashboardScriptPromises.set(id, promise);
+    return promise;
   }
 
   // ---- Constants ----
@@ -115,6 +161,9 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
   private readonly TASK_RECOVERY_WAIT_TEXT = 'Waiting for task recovery...';
   private readonly TASK_RECOVERY_TIMEOUT_TEXT = 'Task recovery timed out';
   private readonly DASHBOARD_TRANSPORT_DIAGNOSTIC_LIMIT = 100;
+  private readonly HTML5_QRCODE_SRC = 'https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js';
+  private readonly LZ_STRING_SRC = 'https://unpkg.com/lz-string@1.5.0/libs/lz-string.min.js';
+  private readonly dashboardScriptPromises = new Map<string, Promise<void>>();
 
   // ---- Persistent state ----
   private hashKey = '';
@@ -123,6 +172,7 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
 
   // ---- Runtime state ----
   private qrScanner: any = null;
+  private qrScannerLoading = false;
   // DEPRECATED v0.9.45rc1: superseded by OpenClaw / Claude Routines -- see PROJECT.md
   // private agents: any[] = [];
   // DEPRECATED v0.9.45rc1: superseded by OpenClaw / Claude Routines -- see PROJECT.md
@@ -1978,8 +2028,26 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
   private startQRScanner(): void {
     if (this.qrScanner) return;
     if (typeof Html5Qrcode === 'undefined') {
-      this.showScanError('QR scanner not available');
-      this.switchTab('paste');
+      if (this.qrScannerLoading) return;
+      this.qrScannerLoading = true;
+      if (this.scanError) {
+        this.scanError.textContent = 'Loading QR scanner...';
+        this.scanError.style.display = 'block';
+      }
+      this.ensureDashboardScript('dash-html5-qrcode', this.HTML5_QRCODE_SRC, 'Html5Qrcode')
+        .then(() => {
+          this.qrScannerLoading = false;
+          if (this.destroyed) return;
+          if (this.loginSection && this.loginSection.style.display !== 'none' && this.tabScan?.classList.contains('active')) {
+            if (this.scanError) this.scanError.style.display = 'none';
+            this.startQRScanner();
+          }
+        })
+        .catch(() => {
+          this.qrScannerLoading = false;
+          this.showScanError('QR scanner not available');
+          this.switchTab('paste');
+        });
       return;
     }
 
@@ -3423,6 +3491,22 @@ export class DashboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
   // ==================== WEBSOCKET ====================
 
   private connectWS(): void {
+    if (typeof LZString === 'undefined') {
+      this.setWsState('reconnecting');
+      this.ensureDashboardScript('dash-lz-string', this.LZ_STRING_SRC, 'LZString')
+        .then(() => {
+          if (!this.destroyed && this.hashKey) this.connectWS();
+        })
+        .catch(() => {
+          this.recordTransportError('cdn-load-failed', 'Could not load LZString before WebSocket connect');
+          if (!this.destroyed && this.hashKey) this.openDashboardWebSocket();
+        });
+      return;
+    }
+    this.openDashboardWebSocket();
+  }
+
+  private openDashboardWebSocket(): void {
     this.disconnectWS();
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = proto + '//' + location.host + '/ws?key=' +

--- a/tests/dashboard-runtime-state.test.js
+++ b/tests/dashboard-runtime-state.test.js
@@ -210,6 +210,11 @@ assert(angularDashboardTsSource.includes('payload.progress.clientLabel') || angu
 assert(angularDashboardTsSource.includes('renderPreviewClientBadge'), 'Angular dashboard preview renders a dedicated client badge');
 assert(angularDashboardTsSource.includes('this.renderPreviewClientBadge(this.previewFrozenBadge, this.lastPreviewOverlayIdentity.clientLabel);'), 'Angular dashboard frozen preview preserves the last trusted client badge');
 assert(angularDashboardTsSource.includes("result: String(progressPayload.result || '').trim()"), 'Angular dashboard remembers structured final result metadata for frozen preview state');
+assert(/loadDashboardCdnScripts\(\): Promise<void>/.test(angularDashboardTsSource), 'Angular dashboard exposes awaitable CDN loader for QR and compressed WS dependencies');
+assert(angularDashboardTsSource.includes('ensureDashboardScript'), 'Angular dashboard has idempotent CDN script loader');
+assert(angularDashboardTsSource.includes('qrScannerLoading'), 'Angular dashboard tracks QR scanner load-in-flight state');
+assert(/ensureDashboardScript\('dash-html5-qrcode'[\s\S]*this\.startQRScanner\(\)/.test(angularDashboardTsSource), 'Angular dashboard waits for html5-qrcode before starting scanner');
+assert(/if \(typeof LZString === 'undefined'\)[\s\S]*ensureDashboardScript\('dash-lz-string'[\s\S]*openDashboardWebSocket/.test(angularDashboardTsSource), 'Angular dashboard loads LZString before opening compressed WS stream');
 assert(angularDashboardHtmlSource.includes('dash-preview-progress-badge'), 'Angular dashboard HTML exposes live preview badge markup');
 assert(angularDashboardHtmlSource.includes('dash-preview-frozen-badge'), 'Angular dashboard HTML exposes frozen preview badge markup');
 assert(angularDashboardScssSource.includes('.dash-preview-client-badge'), 'Angular dashboard SCSS styles the preview client badge');

--- a/tests/qr-pairing.test.js
+++ b/tests/qr-pairing.test.js
@@ -35,6 +35,13 @@ assert(/\/api\/pair\/generate/.test(optionsSource), 'POST /api/pair/generate pre
 assert(/['"]X-FSB-Hash-Key['"]/.test(optionsSource), 'X-FSB-Hash-Key header literal present');
 assert(/\/api\/auth\/register/.test(optionsSource), 'D-01 auto-gen calls /api/auth/register');
 
+console.log('--- relay reconnect contract (SYNC70) ---');
+assert(/function\s+requestDashboardRelayReconnect/.test(optionsSource), 'Sync tab defines relay reconnect helper');
+assert(/action:\s*['"]reconnectDashboardWebSocket['"]/.test(optionsSource), 'Sync tab can ask background.js to reconnect relay WS');
+assert(/requestDashboardRelayReconnect\(serverUrl,\s*data\.hashKey\)/.test(optionsSource), 'new hash key generation reconnects relay to the new room');
+const reconnectBeforePairingTokenCount = (optionsSource.match(/requestDashboardRelayReconnect\(serverUrl,\s*hashKey\);\s*const data = await fetchPairingToken\(serverUrl,\s*hashKey\)/g) || []).length;
+assert(reconnectBeforePairingTokenCount >= 2, 'initial and regenerated QR pairing tokens reconnect relay before minting token');
+
 console.log('--- QR payload contract (QR-01) ---');
 assert(/qrcode\(\s*\d+\s*,\s*['"][LMQH]['"]\s*\)/.test(optionsSource), 'qrcode(typeNumber, level) invocation');
 // Single JSON.stringify call must contain both `t:` and `s:` keys

--- a/tests/sync-tab-runtime.test.js
+++ b/tests/sync-tab-runtime.test.js
@@ -62,6 +62,17 @@ assert(
   '[D-18] cache updates from request.state on every push'
 );
 
+assert(
+  BG.includes("case 'reconnectDashboardWebSocket':"),
+  '[SYNC70] background.js exposes reconnectDashboardWebSocket for Sync-tab pairing refresh'
+);
+
+assert(
+  BG.includes('changes.serverHashKey || changes.serverUrl') &&
+    BG.includes('fsbWebSocket.connect()'),
+  '[SYNC70] background.js reconnects the dashboard relay when Sync server/hash settings change'
+);
+
 console.log('\n--- Phase 213 SYNC-02: ws-client.js push emission + Phase 209 preservation ---');
 
 // Locate _broadcastRemoteControlState body (greedy-stop at next top-level closing brace).
@@ -85,6 +96,13 @@ assert(
 assert(
   WS.includes('var _lastRemoteControlState = null;'),
   '[Phase 209 / D-18] ws-client.js cache at line ~124 preserved (used by snapshot recovery line ~764-765)'
+);
+
+assert(
+  WS.includes("chrome.storage.local.get(['serverHashKey', 'serverUrl'])") &&
+    WS.includes('_normalizeFsbServerUrl(serverUrl)') &&
+    WS.includes("await chrome.storage.local.set({ serverHashKey, serverUrl: resolvedServerUrl })"),
+  '[SYNC70] ws-client connects to the configured Sync server URL and persists the canonical URL with the hash key'
 );
 
 // Phase 209 payload-shape preservation: { enabled, attached, tabId, reason, ownership }


### PR DESCRIPTION
## Summary
- mark v0.9.70 streaming and viewport work complete in planning, with Sync remote control active
- reconnect the extension relay WebSocket when Sync server/hash settings change so dashboard pairing uses the same room
- make dashboard QR and compressed WebSocket dependencies load deterministically before scanner/WS startup
- add regression coverage for Sync relay reconnect and dashboard CDN readiness

## Root Cause
The Sync tab could generate or refresh a pairing token for one server/hash room while the extension relay WebSocket stayed connected to an older room or the hardcoded production server. The dashboard could also race QR/LZString CDN loading and silently fail pairing or compressed message handling.

## Checks
- node tests/sync-tab-runtime.test.js
- node tests/qr-pairing.test.js
- node tests/dashboard-runtime-state.test.js
- node tests/stream-candidate-resolution.test.js
- npm run validate:extension
- npm run showcase:build
- npm run test:mcp-smoke
- npm run showcase:smoke
- PATH=/opt/homebrew/bin:/usr/local/bin:$PATH npm test
- git diff --check
- local dashboard smoke at http://127.0.0.1:4200/dashboard
