### PR TITLE
fix(server): route locale-prefixed marketing paths to per-locale prerenders

### DIFF
--- a/showcase/server/server.js
+++ b/showcase/server/server.js
@@ -17,7 +17,7 @@ const createAgentsRouter = require('./src/routes/agents');
 const createPairRouter = require('./src/routes/pair');
 const { setupWSHandler } = require('./src/ws/handler');
 const { createAcceptLanguageMiddleware } = require('./src/middleware/accept-language');
-const { LOCALES, SOURCE_LOCALE } = require('./src/utils/locale-constants');
+const { LOCALES, SOURCE_LOCALE, LOCALE_SUBPATHS } = require('./src/utils/locale-constants');
 
 // Configuration
 const PORT = parseInt(process.env.PORT) || 3847;
@@ -195,27 +195,57 @@ if (staticPath) {
   }));
 }
 
-// Phase 216 SRV-01 / SRV-02 / D-09 / D-10:
-// Prefer per-route prerendered HTML for marketing routes; whitelist /dashboard
-// exact-match for the SPA shell; fall through to a 404 otherwise. This replaces
-// the previous all-routes -> root-index SPA fallback, which would have shadowed
+// Phase 216 SRV-01 / SRV-02 / D-09 / D-10 + locale-aware extension (2026-05-21):
+// Prefer per-route prerendered HTML for marketing routes; whitelist /dashboard and
+// /stats for the SPA shell; fall through to a 404 otherwise. This replaces the
+// previous all-routes -> root-index SPA fallback, which would have shadowed
 // crawler files and served the wrong <title>/<meta> for /about /privacy /support
 // after Phase 215 prerender landed.
+//
+// Locale extension: requests like /es/agents must serve public/es/agents/index.html.
+// express.static({ redirect: false }) intentionally suppresses the trailing-slash
+// 301, so without this branch /es/agents 404s while /es/agents/ works. Splitting
+// req.path into (localeSubPath, routeWithinLocale) lets one whitelist handle every
+// locale uniformly.
 const marketingRoutes = new Set(['/', '/about', '/agents', '/privacy', '/support']);
+const NON_SOURCE_LOCALE_SUBPATHS = LOCALES
+  .filter(function(loc) { return loc !== SOURCE_LOCALE; })
+  .map(function(loc) { return LOCALE_SUBPATHS[loc]; })
+  .filter(Boolean);
+
+function splitLocaleFromPath(reqPath) {
+  // Returns { localeSubPath, routeWithinLocale }. localeSubPath is '' for EN /
+  // unprefixed paths. Only matches CONFIGURED locale prefixes; arbitrary first
+  // segments (/blog, /api, etc.) are left untouched.
+  for (var i = 0; i < NON_SOURCE_LOCALE_SUBPATHS.length; i++) {
+    var sub = NON_SOURCE_LOCALE_SUBPATHS[i];
+    if (reqPath === '/' + sub) {
+      return { localeSubPath: sub, routeWithinLocale: '/' };
+    }
+    if (reqPath.indexOf('/' + sub + '/') === 0) {
+      return { localeSubPath: sub, routeWithinLocale: reqPath.slice(sub.length + 1) };
+    }
+  }
+  return { localeSubPath: '', routeWithinLocale: reqPath };
+}
+
 app.use((req, res, next) => {
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     return next();
   }
+  const { localeSubPath, routeWithinLocale } = splitLocaleFromPath(req.path);
+  const isMarketing = marketingRoutes.has(routeWithinLocale);
+  const isSpaShell = routeWithinLocale === '/dashboard' || routeWithinLocale === '/stats';
   if (!staticPath) {
-    if (marketingRoutes.has(req.path) || req.path === '/dashboard' || req.path === '/stats') {
+    if (isMarketing || isSpaShell) {
       res.status(503).type('text/plain').send('Showcase build not found. Run `npm --prefix showcase/angular run build` first.');
       return;
     }
     return next();
   }
-  if (marketingRoutes.has(req.path)) {
-    const dir = req.path === '/' ? '' : req.path;
-    const candidate = path.join(staticPath, dir, 'index.html');
+  if (isMarketing) {
+    const routeDir = routeWithinLocale === '/' ? '' : routeWithinLocale;
+    const candidate = path.join(staticPath, localeSubPath, routeDir, 'index.html');
     if (fs.existsSync(candidate)) {
       res.sendFile(candidate);
       return;
@@ -225,10 +255,16 @@ app.use((req, res, next) => {
     // will surface this on the next run.
     return next();
   }
-  if (req.path === '/dashboard' || req.path === '/stats') {
+  if (isSpaShell) {
     // D-10 exact-match whitelist: /dashboard and /stats are SPA-shell routes
     // (RenderMode.Client per app.routes.server.ts). /dashboard/* and /stats/*
-    // are NOT covered and fall through to 404.
+    // are NOT covered and fall through to 404. Per-locale SPA shells are at
+    // public/<locale>/index.html, falling back to root index.html for EN.
+    const shellCandidate = path.join(staticPath, localeSubPath, 'index.html');
+    if (fs.existsSync(shellCandidate)) {
+      res.sendFile(shellCandidate);
+      return;
+    }
     res.sendFile(path.join(staticPath, 'index.html'));
     return;
   }


### PR DESCRIPTION
## Summary

Locale-prefixed marketing paths (`/es/agents`, `/de/about`, `/ja/support`, etc.) returned 404 on production because the marketing-route whitelist on `showcase/server/server.js` only matched bare English paths. Locale homepages worked because `express.static` serves `public/es/index.html` directly. Subpaths failed because `express.static` is configured with `redirect: false` (intentional, to let the custom middleware serve the prerendered `<route>/index.html` without a 301), and the marketing-route middleware below it never matched `/es/agents` since `marketingRoutes` only contained `/`, `/about`, `/agents`, `/privacy`, `/support`.

This is a pre-existing latent bug from `a47efdb29` (2026-05-08) when the all-routes SPA fallback was replaced with the explicit marketing-route whitelist. It was not introduced by PR #75.

## What changed

Split the incoming request path into `(localeSubPath, routeWithinLocale)` using the existing `LOCALE_SUBPATHS` map from `src/utils/locale-constants` (the same source of truth the rest of the i18n system already uses; CI keeps it in sync with the Angular-side constants). The whitelist check now runs against `routeWithinLocale`, and the candidate file path is built under the locale subdirectory.

Same logic applied to the `/dashboard` and `/stats` SPA-shell branch so per-locale SPA shells (`public/es/index.html`, etc.) are preferred when available, with a fallback to the root `index.html`.

`express.static` config untouched. `redirect: false` stays as-is because the EN marketing-route behavior depends on it.

## Verification

Local smoke test against the dist build, all 16 routes:

| Route | Result |
|---|---|
| `/` `/agents` `/about` `/privacy` `/support` | 200 |
| `/es/` `/es/agents` `/es/about` | 200 |
| `/de/agents` `/ja/agents` `/zh-CN/agents` `/zh-TW/agents` | 200 |
| `/es/agents/` (trailing slash) | 200 |
| `/dashboard` `/stats` | 200 |
| `/es/dashboard` `/es/stats` | 200 |
| `/nonexistent` | 404 |

## Test plan

- [ ] CI green (Node test suite, lint, build, crawler smoke)
- [ ] After merge + deploy, manually verify `https://full-selfbrowsing.com/es/agents` returns 200 with Spanish content
- [ ] Verify `https://full-selfbrowsing.com/de/dashboard` returns the SPA shell with German chrome