### PR TITLE
fix(i18n): restore agents.hero.badge morph in non-English locales

### DIFF
--- a/showcase/angular/src/locale/messages.de.xlf
+++ b/showcase/angular/src/locale/messages.de.xlf
@@ -1275,8 +1275,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="agents.hero.badge" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
-        <target state="translated">Bereit für <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
+        <target state="translated">Bereit für <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/agents/agents-page.component.html</context>
           <context context-type="linenumber">7,8</context>

--- a/showcase/angular/src/locale/messages.es.xlf
+++ b/showcase/angular/src/locale/messages.es.xlf
@@ -1275,8 +1275,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="agents.hero.badge" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
-        <target state="translated">Listo para <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
+        <target state="translated">Listo para <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/agents/agents-page.component.html</context>
           <context context-type="linenumber">7,8</context>

--- a/showcase/angular/src/locale/messages.ja.xlf
+++ b/showcase/angular/src/locale/messages.ja.xlf
@@ -1275,8 +1275,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="agents.hero.badge" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
-        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> 対応</target>
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
+        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> 対応</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/agents/agents-page.component.html</context>
           <context context-type="linenumber">7,8</context>

--- a/showcase/angular/src/locale/messages.zh-CN.xlf
+++ b/showcase/angular/src/locale/messages.zh-CN.xlf
@@ -1275,8 +1275,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="agents.hero.badge" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
-        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> 就绪</target>
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
+        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> 就绪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/agents/agents-page.component.html</context>
           <context context-type="linenumber">7,8</context>

--- a/showcase/angular/src/locale/messages.zh-TW.xlf
+++ b/showcase/angular/src/locale/messages.zh-TW.xlf
@@ -1275,8 +1275,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="agents.hero.badge" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
-        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>OpenClaw<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> 就緒</target>
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> Ready</source>
+        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot; class=&quot;agents-hero-morph&quot;&gt;"/><x id="INTERPOLATION" equiv-text="{{ currentToken }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> 就緒</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/agents/agents-page.component.html</context>
           <context context-type="linenumber">7,8</context>


### PR DESCRIPTION
## Summary

The /agents page hero badge (`OpenClaw` ↔ `Hermes` matrix-style text morph + image swap) **only animated in English**. In every other locale (es, de, ja, zh-CN, zh-TW) the badge was permanently stuck on `OpenClaw` because the per-locale XLF translations baked the literal text `OpenClaw` into the target string. The interpolation binding `{{ currentToken }}` was lost during the build, so the morph engine had nothing to update.

## Root cause

When the badge text was a plain literal (`OpenClaw Ready`), translators produced targets like:

```xml
<target>Listo para <span>OpenClaw</span></target>
```

The morph commits (`ef144f38`, `c883c238`) replaced the literal with an interpolation:

```html
<span>{{ currentToken }}</span> Ready
```

The EN source string in `messages.xlf` was regenerated (CI-02 gate forced it during PR #75), but the 5 per-locale XLF files were never re-synced. They still hold the pre-morph baked-in `OpenClaw` literal. Angular's i18n compiler substitutes the locale target verbatim, so non-EN builds get static text instead of the dynamic binding.

## Fix

Updated `<source>` and `<target>` in all 5 locale XLF files so the badge interpolation placeholder (`<x id="INTERPOLATION" equiv-text="{{ currentToken }}"/>`) and the new class (`class="agents-hero-morph"`) are preserved. The native surrounding text in each translation is unchanged:

| Locale | Pattern after fix |
|---|---|
| es | `Listo para <span>{{currentToken}}</span>` |
| de | `Bereit für <span>{{currentToken}}</span>` |
| ja | `<span>{{currentToken}}</span> 対応` |
| zh-CN | `<span>{{currentToken}}</span> 就绪` |
| zh-TW | `<span>{{currentToken}}</span> 就緒` |

Trans-unit ID `agents.hero.badge` unchanged so translator history is preserved.

## Verification

Rebuilt all 6 locales locally and confirmed the rendered hero badge in each of `agents/index.html`, `es/agents/index.html`, `de/agents/index.html`, `ja/agents/index.html`, `zh-CN/agents/index.html`, `zh-TW/agents/index.html` now contains the same structural span:

```html
<span class="agents-hero-morph" translate="no">OpenClaw</span>
```

surrounded by the locale-appropriate "ready" chrome. The literal `OpenClaw` shown here is the SSR-rendered initial value of `currentToken`. Once JS hydrates, the morph engine cycles it identically across all locales.

## Test plan

- [ ] CI green
- [ ] After merge + deploy, hard-reload `https://full-selfbrowsing.com/es/agents`, `/de/agents`, `/ja/agents`, `/zh-CN/agents`, `/zh-TW/agents` and confirm the badge text cycles between `OpenClaw` and `Hermes` every 3 seconds (matching EN behavior)
- [ ] Image mark continues to swap in sync
- [ ] Hermes-only dark-mode white filter still applies