### PR TITLE
fix(stats): surface real MCP client labels (drop k-anonymity floor; allowlist labels are public)

### DIFF
--- a/showcase/server/src/telemetry/housekeeper.js
+++ b/showcase/server/src/telemetry/housekeeper.js
@@ -5,12 +5,19 @@
  *   1. DELETE telemetry_events older than 7 days (retention policy).
  *   2. Re-aggregate today + yesterday per install_uuid into telemetry_rollups_daily.
  *   3. Recompute telemetry_global_aggregates for today + yesterday, applying
- *      a k>=2 anonymity floor on the mcp_client popular list (below-k labels
- *      bucket as "Other (N=<count>)"). The floor was 5 in v0.9.69 but at
- *      single-digit total install counts no label can mathematically clear
- *      k=5, so /stats showed only "Other". Floor lowered to 2 for the
- *      dev-phase visibility tradeoff -- raise back to 5 once total install
- *      count comfortably exceeds 50.
+ *      a k>=K_ANONYMITY_FLOOR anonymity floor on the mcp_client popular list
+ *      (below-k labels bucket as "Other"). Floor history:
+ *        - v0.9.69: floor=5 (free-form-label defaults)
+ *        - v0.9.70: floor=2 (dev-phase visibility tradeoff)
+ *        - v0.9.70+ (this change): floor=1, effectively DISABLING the floor.
+ *      Rationale: MCP_CLIENT_ALLOWLIST in routes/telemetry.js is a FIXED
+ *      PUBLIC 13-label set (Claude, Codex, ChatGPT, Perplexity, Windsurf,
+ *      Cursor, Antigravity, OpenCode, OpenClaw, OpenClaw 🦀, Grok, Gemini,
+ *      Hermes + 'unknown'). The label set carries no identifying information
+ *      beyond the per-label install count, and that count is already exposed
+ *      via total_users. Bucketing single-install labels into "Other" only
+ *      hides legitimate diversity at single-digit install totals (the live
+ *      bug: 3 installs, 3 distinct clients, all surfaced as 100% "Other").
  *   4. Nudge salt rotation by calling hashIp('0.0.0.0', db) -- the result is
  *      discarded; '0.0.0.0' is a harmless throwaway literal; the side effect
  *      is the lazy getOrMintTodaySalt() inside hashIp.
@@ -28,7 +35,7 @@ const { hashIp } = require('../utils/telemetry-hash');
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-const K_ANONYMITY_FLOOR = 2;
+const K_ANONYMITY_FLOOR = 1;
 
 function floorToUtcDayMs(ms) {
   const d = new Date(ms);
@@ -78,25 +85,19 @@ function runHousekeeperTick(db, queries, nowMs = Date.now()) {
       const popularMcpRaw = queries.selectPopularMcpForDayRange.all(dayStart, dayEnd);
 
       // k>=K_ANONYMITY_FLOOR anonymity floor per D-07 (WR-01 fix from Phase 273
-      // review). Floor was 5 at milestone v0.9.69; lowered to 2 in v0.9.70 once
-      // it became clear that no real client could clear k=5 at single-digit
-      // install totals (every popular_mcp_clients entry collapsed to "Other").
+      // review). Floor history: 5 (v0.9.69) -> 2 (v0.9.70) -> 1 (this change).
+      // At floor=1, every row from selectPopularMcpForDayRange already satisfies
+      // `uniq >= 1` (GROUP BY emits no zero-count rows), so `above` equals
+      // `popularMcpRaw`, `belowInstalls` is 0, and no "Other" bucket is ever
+      // emitted. The filter + reduce stay in place so a future bump to floor>=2
+      // (e.g. if MCP_CLIENT_ALLOWLIST ever opens to free-form labels) re-engages
+      // bucketing without further plumbing.
       //
-      // Each row's `uniq` is already `COUNT(DISTINCT install_uuid)` per mcp_client
-      // (see queries.js:selectPopularMcpForDayRange). Labels with uniq >= floor
-      // surface unchanged; labels with uniq < floor collapse into a single "Other"
-      // bucket whose count is the SUM of below-k install counts (NOT the number
-      // of distinct below-k labels). This corrects two bugs in the prior code:
-      //
-      //   1. The "Other" bucket previously reported the count of distinct LABELS
-      //      below k (e.g. 4 if four labels each had uniq=1..4). Downstream
-      //      consumers reading `uniq` as installs got a wrong number.
-      //   2. If only one below-k label existed and that label had uniq=1, the
-      //      output was `{ mcp_client: 'Other (N=1)', uniq: 1 }` — surfacing
-      //      a singleton install under a generic name, which still violates k.
-      //
-      // The fix sums the actual installs and SUPPRESSES the bucket when even
-      // the aggregate below-k install count is itself < k.
+      // Each row's `uniq` is COUNT(DISTINCT install_uuid) per mcp_client (see
+      // queries.js:selectPopularMcpForDayRange). The historical WR-01 fix --
+      // SUMMING below-k installs (not COUNTING below-k labels) and SUPPRESSING
+      // the bucket when the aggregate is itself < floor -- is preserved verbatim
+      // below for that future-bump case.
       const above = popularMcpRaw.filter((r) => (r.uniq || 0) >= K_ANONYMITY_FLOOR);
       const belowInstalls = popularMcpRaw
         .filter((r) => (r.uniq || 0) < K_ANONYMITY_FLOOR)

--- a/tests/server-telemetry-housekeeper.test.js
+++ b/tests/server-telemetry-housekeeper.test.js
@@ -22,7 +22,7 @@ const Database = require(require.resolve('better-sqlite3', { paths: [SERVER_NM] 
 
 const { initializeDatabase } = require(path.join(__dirname, '..', 'showcase', 'server', 'src', 'db', 'schema'));
 const Queries = require(path.join(__dirname, '..', 'showcase', 'server', 'src', 'db', 'queries'));
-const { runHousekeeperTick, floorToUtcDayMs } = require(path.join(__dirname, '..', 'showcase', 'server', 'src', 'telemetry', 'housekeeper'));
+const { runHousekeeperTick, floorToUtcDayMs, K_ANONYMITY_FLOOR } = require(path.join(__dirname, '..', 'showcase', 'server', 'src', 'telemetry', 'housekeeper'));
 
 let passed = 0;
 let failed = 0;
@@ -128,19 +128,25 @@ check('global aggregate exists for yesterday', !!globalYesterday, `got ${JSON.st
 check('global yesterday.unique_installs === 1 (A)', globalYesterday && globalYesterday.unique_installs === 1, `got ${JSON.stringify(globalYesterday)}`);
 
 // popular_mcp_json: today has Claude (1 distinct install, A) and Codex (1 distinct install, B).
-// Both labels are below the k=2 floor (uniq=1 < 2). The fix in WR-01 (Phase 273 review) sums
-// installs across below-k labels (1 + 1 = 2). The aggregate below-k install count (2) is
-// >= k=2, so the "Other" bucket SURFACES with uniq=2. Per-label names are still suppressed
-// (each label's uniq=1 < k=2) so anonymity at the chosen k is preserved.
+// Floor history: k=5 (v0.9.69, bucket SUPPRESSED -> []) -> k=2 (v0.9.70, both labels below floor,
+// aggregate 1+1=2 >= floor -> single "Other" bucket uniq=2) -> k=1 (this fix, both labels >= floor
+// -> both labels surface UNCHANGED as separate rows, no "Other" bucket emitted).
 //
-// History: this assertion was originally written against k=5 (bucket SUPPRESSED -> empty
-// array). Floor lowered to k=2 in v0.9.70 once it became clear no real client could clear
-// k=5 at single-digit total install counts -- /stats showed only "Other" forever.
+// Rationale for k=1: MCP_CLIENT_ALLOWLIST in routes/telemetry.js is a FIXED PUBLIC 13-label set
+// whose contents leak no identifying information beyond install counts (already exposed via
+// total_users). See housekeeper.js comment block for the full justification.
 const popularToday = JSON.parse(globalToday.popular_mcp_json);
-check('popular_mcp_json applies k=2 floor: per-label below k, aggregate 2 >= k -> single "Other" bucket with uniq=2',
-  Array.isArray(popularToday) && popularToday.length === 1
-    && popularToday[0].mcp_client === 'Other'
-    && popularToday[0].uniq === 2,
+check('K_ANONYMITY_FLOOR is exported and equals 1 (regression guard: any bump to >=2 will fail this test)',
+  K_ANONYMITY_FLOOR === 1,
+  `got K_ANONYMITY_FLOOR=${K_ANONYMITY_FLOOR}`
+);
+check('popular_mcp_json at k=1: both real labels (Claude + Codex) surface as separate rows with uniq=1, no "Other" bucket',
+  Array.isArray(popularToday)
+    && popularToday.length === 2
+    && popularToday.every((r) => r.uniq === 1)
+    && popularToday.some((r) => r.mcp_client === 'Claude')
+    && popularToday.some((r) => r.mcp_client === 'Codex')
+    && popularToday.every((r) => r.mcp_client !== 'Other'),
   `got ${JSON.stringify(popularToday)}`
 );
 


### PR DESCRIPTION
## Summary

/stats "Popular agents" tab shows 100% "Other" instead of real MCP client names. Live evidence:

```
$ curl https://full-selfbrowsing.com/api/public-stats/global
"popular_mcp_clients": [{"label": "Other", "uniq": 3}]
```

Three distinct installs today, each with a different `mcp_client`, each at `uniq=1`, each below `K_ANONYMITY_FLOOR=2` in `showcase/server/src/telemetry/housekeeper.js:31`, so the housekeeper collapses them all to "Other".

## Root cause

K-anonymity floor was designed for free-form labels where a unique entry could fingerprint a single user. But `MCP_CLIENT_ALLOWLIST` in `showcase/server/src/routes/telemetry.js:47` is a **fixed public 13-label set** (Claude, Codex, ChatGPT, Perplexity, Windsurf, Cursor, Antigravity, OpenCode, OpenClaw, OpenClaw 🦀, Grok, Gemini, Hermes, plus `unknown`). The labels themselves leak no identifying value -- only the install count does, which is already exposed via the `total_users` headline anyway.

## Fix

Lower `K_ANONYMITY_FLOOR` from `2` to `1` in housekeeper. The aggregation math is preserved verbatim and becomes a no-op at floor=1:

- `selectPopularMcpForDayRange` `GROUP BY mcp_client` always emits `uniq >= 1` rows
- With floor=1: `above = popularMcpRaw` (everything), `belowInstalls = 0`, "Other" bucket suppressed
- All real labels surface

Rewrote the two explanatory comment blocks in housekeeper.js to cite the new rationale (public allowlist → no identifying value at uniq=1). Updated `tests/server-telemetry-housekeeper.test.js` to pin `K_ANONYMITY_FLOOR === 1` as a regression guard and assert that two distinct mcp_client labels with uniq=1 surface as separate rows (not a single "Other" bucket).

## Non-impact

- **Extension**: zero changes (user constraint).
- **API contract**: `popular_mcp_clients` shape (`[{label, uniq}]`) unchanged.
- **DB schema**: no migration -- the hourly housekeeper UPSERT will overwrite the stale `Other` JSON in `telemetry_global_aggregates.popular_mcp_json` on first tick after deploy (boot-tick fires via `setImmediate` in `startHousekeeper`, so within ~1 min of deploy).
- **Frontend**: already renders whatever labels arrive; no changes needed.

## Test plan
- [x] `node tests/server-telemetry-housekeeper.test.js` -> 25 passed
- [x] `node tests/server-public-stats-headline.test.js` -> 33 passed (API contract unchanged)
- [x] `node tests/server-telemetry-allowlist.test.js` -> 15 passed (orthogonal: tests 'Other' as a *rejected ingest value*)
- [x] `node tests/fsb-telemetry-service.test.js` -> 68 passed
- [x] `git diff --name-only extension/` -> empty (constraint satisfied)
- [ ] CI green
- [ ] Post-deploy: `curl https://full-selfbrowsing.com/api/public-stats/global` returns real label names within ~1 min of fly.io rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)