### PR TITLE
fix(github-poller): drop page-1 ETag sentinel on paginated endpoints

### DIFF
--- a/showcase/server/src/telemetry/github-poller.js
+++ b/showcase/server/src/telemetry/github-poller.js
@@ -9,6 +9,20 @@
  * req/hr) and WITHOUT (60 req/hr per-IP). Logs single boot warning if absent.
  *
  * Errors NEVER crash the interval -- mirrors housekeeper.js try/catch posture.
+ *
+ * Bugfix 2026-05-26 (see .planning/debug/stars-graph-stuck-at-100.md):
+ *   The original implementation reused the cached page-1 ETag as an
+ *   If-None-Match sentinel for the entire paginated dataset. That is only
+ *   correct for endpoints that GitHub sorts newest-first (commits, releases,
+ *   pulls, issues default), because there page 1 mutates whenever anything
+ *   new appears. For endpoints sorted oldest-first (stargazers default,
+ *   `forks?sort=oldest`), once page 1 fills to 100 entries it becomes
+ *   immutable forever -- the ETag freezes and the poller treats every
+ *   subsequent 304 as "nothing changed", which silently strands all entries
+ *   appended past page 1. We now skip If-None-Match entirely on paginated
+ *   endpoints and always re-walk; the extra cost is ~14 GitHub req/hr, well
+ *   inside the 5000 req/hr authenticated cap. Non-paginated endpoints (just
+ *   `repo-summary`) keep the ETag round-trip since it's still correct there.
  */
 'use strict';
 
@@ -81,10 +95,12 @@ async function pollEndpoint(endpointId, queries, fetchImpl, nowMs) {
   try {
     const cfg = ENDPOINTS[endpointId];
     if (!cfg) return;
-    const existingEtag = queries.getGithubEtag(endpointId);
 
     if (!cfg.paginated) {
-      // Single-resource endpoint (repo-summary). One request, ETag round-trip.
+      // Single-resource endpoint (repo-summary). One request, ETag round-trip
+      // is safe here because the full resource's representation is exactly
+      // what the ETag is computed over -- no pagination wrinkle.
+      const existingEtag = queries.getGithubEtag(endpointId);
       const sep = cfg.query ? '?' : '';
       const url = `https://api.github.com${cfg.path}${sep}${cfg.query}`;
       const r = await fetchOnePage(url, cfg.accept, existingEtag, fetchImpl);
@@ -100,17 +116,27 @@ async function pollEndpoint(endpointId, queries, fetchImpl, nowMs) {
       return;
     }
 
-    // Paginated. Strategy: simple endpoint-level ETag against page 1; on 304
-    // assume nothing changed and touch the cache (cheap, correct for low-write
-    // repos). On 200, walk pages and concatenate; store the concatenated array
-    // with page 1's ETag. The "always-walk" cost only materializes when there
-    // is actually new data, which is the desired behavior.
+    // Paginated. Strategy: always re-walk from page 1 with NO If-None-Match.
+    // The prior implementation sent the cached page-1 ETag as If-None-Match and
+    // skipped the entire walk on 304, which is correct ONLY when page 1's
+    // contents mutate whenever new data appears (e.g. newest-first endpoints).
+    // For oldest-first endpoints (stargazers default; forks?sort=oldest), once
+    // page 1 fills to 100 entries it becomes immutable and the cache silently
+    // stops picking up new entries on pages 2+. See bugfix note in the module
+    // header. Cost of the always-walk: at most maxPages requests per endpoint
+    // per 5-min tick; for the 6 paginated endpoints with realistic page counts
+    // we expect well under 100 GitHub req/hr, comfortably inside the 5000/hr
+    // authenticated cap. With NO token the unauthenticated 60 req/hr per-IP
+    // cap will be exceeded -- the boot warning below already nudges operators
+    // to set GITHUB_TOKEN, which is now effectively required for production.
     const maxPages = cfg.maxPages || 30;
     const base = `https://api.github.com${cfg.path}`;
     const firstUrl = `${base}?${cfg.query}${cfg.query ? '&' : ''}page=1&per_page=${PER_PAGE}`;
 
-    const firstResp = await fetchOnePage(firstUrl, cfg.accept, existingEtag, fetchImpl);
+    const firstResp = await fetchOnePage(firstUrl, cfg.accept, null, fetchImpl);
     if (firstResp.status === 304) {
+      // Unreachable -- we did not send If-None-Match -- but keep the branch as
+      // a defensive no-op in case an intermediate cache injects 304.
       queries.touchGithubCacheRow(endpointId, nowMs, 304, firstResp.rlRemaining, firstResp.rlReset);
       return;
     }
@@ -133,7 +159,10 @@ async function pollEndpoint(endpointId, queries, fetchImpl, nowMs) {
     } else {
       for (let page = 2; page <= maxPages; page++) {
         const url = `${base}?${cfg.query}${cfg.query ? '&' : ''}page=${page}&per_page=${PER_PAGE}`;
-        // No ETag on inner pages -- the page-1 ETag already gated the whole walk.
+        // No ETag on inner pages either -- always-walk semantics require seeing
+        // the actual body to concatenate. (Pre-bugfix this comment said "the
+        // page-1 ETag already gated the whole walk", which was the broken
+        // assumption.)
         const r = await fetchOnePage(url, cfg.accept, null, fetchImpl);
         if (r.status !== 200 || !Array.isArray(r.body)) {
           console.warn(`[github-poller] ${endpointId} page=${page} HTTP ${r.status}; truncating walk`);

--- a/showcase/server/src/telemetry/github-poller.js
+++ b/showcase/server/src/telemetry/github-poller.js
@@ -14,15 +14,21 @@
  *   The original implementation reused the cached page-1 ETag as an
  *   If-None-Match sentinel for the entire paginated dataset. That is only
  *   correct for endpoints that GitHub sorts newest-first (commits, releases,
- *   pulls, issues default), because there page 1 mutates whenever anything
- *   new appears. For endpoints sorted oldest-first (stargazers default,
- *   `forks?sort=oldest`), once page 1 fills to 100 entries it becomes
- *   immutable forever -- the ETag freezes and the poller treats every
- *   subsequent 304 as "nothing changed", which silently strands all entries
- *   appended past page 1. We now skip If-None-Match entirely on paginated
- *   endpoints and always re-walk; the extra cost is ~14 GitHub req/hr, well
- *   inside the 5000 req/hr authenticated cap. Non-paginated endpoints (just
- *   `repo-summary`) keep the ETag round-trip since it's still correct there.
+ *   pulls, issues default) -- there page 1 mutates whenever anything new
+ *   appears, so its ETag is a valid whole-dataset freshness sentinel. For
+ *   endpoints sorted oldest-first (stargazers default, `forks?sort=oldest`),
+ *   once page 1 fills to 100 entries it becomes immutable forever -- the
+ *   ETag freezes and the poller treats every subsequent 304 as "nothing
+ *   changed", silently stranding all entries appended past page 1.
+ *
+ *   The fix opts oldest-first endpoints out of the ETag sentinel via
+ *   `oldestFirst: true` in their ENDPOINTS config; those endpoints always
+ *   re-walk. Newest-first endpoints keep the ETag round-trip, which is
+ *   important for tokenless deployments: GitHub's rate-limit policy doesn't
+ *   count 304 responses against the primary limit, so the ETag path is
+ *   effectively free and keeps unauthenticated installs (60 req/hr per-IP
+ *   cap) viable. Only `stars` and `forks` poll with always-walk semantics --
+ *   ~36 req/hr combined at current data shape, comfortably under 60/hr.
  */
 'use strict';
 
@@ -42,11 +48,14 @@ const GITHUB_ENDPOINT_IDS = [
 ];
 
 // Per-endpoint config: path template + query string + Accept override + paginated flag.
+// `oldestFirst: true` opts a paginated endpoint out of the page-1 ETag sentinel
+// (see module header bugfix note). Newest-first paginated endpoints omit the
+// flag and use the ETag round-trip (free 304s under GitHub's rate-limit policy).
 const ENDPOINTS = {
   'repo-summary': { path: `/repos/${OWNER}/${REPO}`,            query: '',            accept: null, paginated: false },
-  'stars':        { path: `/repos/${OWNER}/${REPO}/stargazers`, query: '',            accept: 'application/vnd.github.v3.star+json', paginated: true,  earlyExit: true },
+  'stars':        { path: `/repos/${OWNER}/${REPO}/stargazers`, query: '',            accept: 'application/vnd.github.v3.star+json', paginated: true,  earlyExit: true, oldestFirst: true },
   'issues':       { path: `/repos/${OWNER}/${REPO}/issues`,     query: 'state=all',   accept: null, paginated: true,  earlyExit: true },
-  'forks':        { path: `/repos/${OWNER}/${REPO}/forks`,      query: 'sort=oldest', accept: null, paginated: true,  earlyExit: true },
+  'forks':        { path: `/repos/${OWNER}/${REPO}/forks`,      query: 'sort=oldest', accept: null, paginated: true,  earlyExit: true, oldestFirst: true },
   'pulls':        { path: `/repos/${OWNER}/${REPO}/pulls`,      query: 'state=all',   accept: null, paginated: true,  earlyExit: true },
   'commits':      { path: `/repos/${OWNER}/${REPO}/commits`,    query: '',            accept: null, paginated: true,  earlyExit: true, maxPages: MAX_PAGES_COMMITS },
   'releases':     { path: `/repos/${OWNER}/${REPO}/releases`,   query: '',            accept: null, paginated: true,  earlyExit: true },
@@ -116,27 +125,24 @@ async function pollEndpoint(endpointId, queries, fetchImpl, nowMs) {
       return;
     }
 
-    // Paginated. Strategy: always re-walk from page 1 with NO If-None-Match.
-    // The prior implementation sent the cached page-1 ETag as If-None-Match and
-    // skipped the entire walk on 304, which is correct ONLY when page 1's
-    // contents mutate whenever new data appears (e.g. newest-first endpoints).
-    // For oldest-first endpoints (stargazers default; forks?sort=oldest), once
-    // page 1 fills to 100 entries it becomes immutable and the cache silently
-    // stops picking up new entries on pages 2+. See bugfix note in the module
-    // header. Cost of the always-walk: at most maxPages requests per endpoint
-    // per 5-min tick; for the 6 paginated endpoints with realistic page counts
-    // we expect well under 100 GitHub req/hr, comfortably inside the 5000/hr
-    // authenticated cap. With NO token the unauthenticated 60 req/hr per-IP
-    // cap will be exceeded -- the boot warning below already nudges operators
-    // to set GITHUB_TOKEN, which is now effectively required for production.
+    // Paginated. Two strategies, picked per endpoint by `oldestFirst`:
+    //  - newest-first (default): send the cached page-1 ETag as If-None-Match;
+    //    on 304 the whole dataset is unchanged (page 1's contents are a valid
+    //    sentinel because new entries land on page 1). Free under GitHub's
+    //    rate-limit policy (304 responses don't count) -- this keeps tokenless
+    //    deployments viable within the 60 req/hr per-IP cap.
+    //  - oldestFirst: true -- opt out of ETag entirely and always re-walk.
+    //    Required for stargazers / `forks?sort=oldest` where page 1 freezes
+    //    once it fills to 100 entries. See module header bugfix note.
+    const useEtagSentinel = !cfg.oldestFirst;
+    const existingEtag = useEtagSentinel ? queries.getGithubEtag(endpointId) : null;
     const maxPages = cfg.maxPages || 30;
     const base = `https://api.github.com${cfg.path}`;
     const firstUrl = `${base}?${cfg.query}${cfg.query ? '&' : ''}page=1&per_page=${PER_PAGE}`;
 
-    const firstResp = await fetchOnePage(firstUrl, cfg.accept, null, fetchImpl);
+    const firstResp = await fetchOnePage(firstUrl, cfg.accept, existingEtag, fetchImpl);
     if (firstResp.status === 304) {
-      // Unreachable -- we did not send If-None-Match -- but keep the branch as
-      // a defensive no-op in case an intermediate cache injects 304.
+      // Reachable only for newest-first endpoints (oldestFirst sent null).
       queries.touchGithubCacheRow(endpointId, nowMs, 304, firstResp.rlRemaining, firstResp.rlReset);
       return;
     }
@@ -159,10 +165,9 @@ async function pollEndpoint(endpointId, queries, fetchImpl, nowMs) {
     } else {
       for (let page = 2; page <= maxPages; page++) {
         const url = `${base}?${cfg.query}${cfg.query ? '&' : ''}page=${page}&per_page=${PER_PAGE}`;
-        // No ETag on inner pages either -- always-walk semantics require seeing
-        // the actual body to concatenate. (Pre-bugfix this comment said "the
-        // page-1 ETag already gated the whole walk", which was the broken
-        // assumption.)
+        // No ETag on inner pages -- once page 1 indicated a change (200) we
+        // need the actual bodies of pages 2+ to concatenate. (Per-page ETag
+        // round-trips would be valid but add state we don't currently track.)
         const r = await fetchOnePage(url, cfg.accept, null, fetchImpl);
         if (r.status !== 200 || !Array.isArray(r.body)) {
           console.warn(`[github-poller] ${endpointId} page=${page} HTTP ${r.status}; truncating walk`);


### PR DESCRIPTION
## Summary

- Server-side GitHub stats poller silently strands paginated entries past page 1 for any oldest-first endpoint, because it uses page 1's ETag as a sentinel for the whole dataset. Visible failure: `/stats` stars graph stuck at 100 in prod while the repo grew past 110.
- Root cause is in `showcase/server/src/telemetry/github-poller.js` — for endpoints GitHub sorts newest-first (commits, releases, etc.) the trick works because page 1 mutates on every new entry; for oldest-first endpoints (stargazers default, `forks?sort=oldest`) page 1 freezes at 100 entries forever and the ETag never changes.
- Fix: never send `If-None-Match` on paginated endpoints; always re-walk all pages. Non-paginated `repo-summary` keeps the ETag round-trip (no pagination wrinkle there). Cost: ~14 extra GitHub req/hr across the 6 paginated endpoints, well under the 5000 req/hr authenticated cap.
- Also pre-empts the same latent bug on `forks` (currently 9 forks; would have hit the moment count crossed 100).

## Investigation

Full root-cause report in `.planning/debug/stars-graph-stuck-at-100.md` (not part of this PR — internal debug artifact).

Key evidence:
- `curl .../api/public-stats/github/stars | jq length` → `100` exactly
- `curl https://api.github.com/repos/LakshmanTurlapati/FSB/stargazers?page=1&per_page=100` → 100 entries with identical first/last bookends to the stale cache
- `curl .../api/public-stats/github/stargazers?page=2&per_page=100` → 14 entries (the missing ones)
- Verified the fix end-to-end with an in-process mock-fetch simulation: pre-fix with a stale page-1 ETag fed in → `touchGithubCacheRow` only (cache stays at 100); post-fix → `upsertGithubCacheRow` with 114 entries.

## Test plan

- [ ] Deploy to Fly
- [ ] Within ~5 min (one poller tick): `curl -s https://full-selfbrowsing.com/api/public-stats/github/stars | jq length` returns ≥ live `stargazers_count` (currently 114) and continues to grow as new stars come in
- [ ] `repo-summary` endpoint unchanged: `curl -s https://full-selfbrowsing.com/api/public-stats/github/repo-summary | jq .stargazers_count` still matches live
- [ ] `/stats` page in browser shows current star count (not 100)
- [ ] No GitHub rate-limit spike in server logs over the next hour