### PR TITLE
feat(stats): hide nav + minimize footer + add orange glow on /stats only

### DIFF
--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
@@ -1,76 +1,87 @@
-<nav class="nav" [class.scrolled]="navScrolled">
-  <div class="nav-inner">
-    <a routerLink="/" class="nav-brand" (click)="closeMobileMenu()">
-       
-      <img src="assets/icon128.png" i18n-alt="@@shell.nav.brand.logo.alt" alt="FSB Logo" width="32" height="32" decoding="async">
-      <span i18n="@@shell.nav.brand.text" [attr.translate]="'no'">FSB</span>
-    </a>
-    <div class="nav-links">
-      <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" i18n="@@shell.nav.desktop.home">Home</a>
-      <a routerLink="/about" routerLinkActive="active" i18n="@@shell.nav.desktop.about">About</a>
-      <a routerLink="/agents" routerLinkActive="active" i18n="@@shell.nav.desktop.agents">Agents</a>
-      <a routerLink="/dashboard" routerLinkActive="active" i18n="@@shell.nav.desktop.dashboard">Dashboard</a>
-      <a routerLink="/privacy" routerLinkActive="active" i18n="@@shell.nav.desktop.privacy">Privacy</a>
-      <a routerLink="/support" routerLinkActive="active" i18n="@@shell.nav.desktop.support">Support</a>
-    </div>
-    <div class="nav-actions">
-       
-      <a href="https://github.com/lakshmanturlapati/FSB" target="_blank" rel="noopener" class="btn btn-sm btn-github" i18n="@@shell.nav.desktop.github" [attr.translate]="'no'">
-        <i class="fa-brands fa-github"></i> GitHub
-      </a>
-    </div>
-    <button class="nav-toggle" [class.active]="mobileMenuOpen" i18n-aria-label="@@shell.nav.toggle.aria" aria-label="Toggle navigation" (click)="toggleMobileMenu()">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-  </div>
-</nav>
-<div class="nav-mobile" [class.active]="mobileMenuOpen">
-  <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.home">Home</a>
-  <a routerLink="/about" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.about">About</a>
-  <a routerLink="/agents" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.agents">Agents</a>
-  <a routerLink="/dashboard" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.dashboard">Dashboard</a>
-  <a routerLink="/privacy" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.privacy">Privacy</a>
-  <a routerLink="/support" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.support">Support</a>
-   
-  <a href="https://github.com/lakshmanturlapati/FSB" target="_blank" rel="noopener" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.github" [attr.translate]="'no'"><i class="fa-brands fa-github"></i> GitHub</a>
-</div>
+@if (isStatsRoute) {
+  <div class="stats-glow-bg" aria-hidden="true"></div>
+  <button type="button" class="stats-back-btn" (click)="goBack()" aria-label="Go back">
+    <i class="ph ph-arrow-left"></i>
+  </button>
+}
 
-<main>
+@if (!isStatsRoute) {
+  <nav class="nav" [class.scrolled]="navScrolled">
+    <div class="nav-inner">
+      <a routerLink="/" class="nav-brand" (click)="closeMobileMenu()">
+
+        <img src="assets/icon128.png" i18n-alt="@@shell.nav.brand.logo.alt" alt="FSB Logo" width="32" height="32" decoding="async">
+        <span i18n="@@shell.nav.brand.text" [attr.translate]="'no'">FSB</span>
+      </a>
+      <div class="nav-links">
+        <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" i18n="@@shell.nav.desktop.home">Home</a>
+        <a routerLink="/about" routerLinkActive="active" i18n="@@shell.nav.desktop.about">About</a>
+        <a routerLink="/agents" routerLinkActive="active" i18n="@@shell.nav.desktop.agents">Agents</a>
+        <a routerLink="/dashboard" routerLinkActive="active" i18n="@@shell.nav.desktop.dashboard">Dashboard</a>
+        <a routerLink="/privacy" routerLinkActive="active" i18n="@@shell.nav.desktop.privacy">Privacy</a>
+        <a routerLink="/support" routerLinkActive="active" i18n="@@shell.nav.desktop.support">Support</a>
+      </div>
+      <div class="nav-actions">
+
+        <a href="https://github.com/lakshmanturlapati/FSB" target="_blank" rel="noopener" class="btn btn-sm btn-github" i18n="@@shell.nav.desktop.github" [attr.translate]="'no'">
+          <i class="fa-brands fa-github"></i> GitHub
+        </a>
+      </div>
+      <button class="nav-toggle" [class.active]="mobileMenuOpen" i18n-aria-label="@@shell.nav.toggle.aria" aria-label="Toggle navigation" (click)="toggleMobileMenu()">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+  </nav>
+  <div class="nav-mobile" [class.active]="mobileMenuOpen">
+    <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.home">Home</a>
+    <a routerLink="/about" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.about">About</a>
+    <a routerLink="/agents" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.agents">Agents</a>
+    <a routerLink="/dashboard" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.dashboard">Dashboard</a>
+    <a routerLink="/privacy" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.privacy">Privacy</a>
+    <a routerLink="/support" routerLinkActive="active" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.support">Support</a>
+
+    <a href="https://github.com/lakshmanturlapati/FSB" target="_blank" rel="noopener" (click)="closeMobileMenu()" i18n="@@shell.nav.mobile.github" [attr.translate]="'no'"><i class="fa-brands fa-github"></i> GitHub</a>
+  </div>
+}
+
+<main [class.stats-main]="isStatsRoute">
   <ng-content></ng-content>
 </main>
 
 <footer class="footer">
   <div class="container">
-    <div class="footer-inner">
-      <div class="footer-brand">
-         
-        <img src="assets/icon48.png" i18n-alt="@@shell.footer.brand.logo.alt" alt="FSB" width="28" height="28" loading="lazy" decoding="async">
-        <span i18n="@@shell.footer.brand.text" [attr.translate]="'no'">FSB</span>
-      </div>
-      <div class="footer-links">
-        <div class="footer-column">
-          <h4 i18n="@@shell.footer.col.pages.title">Pages</h4>
-          <a routerLink="/" i18n="@@shell.footer.col.pages.home">Home</a>
-          <a routerLink="/about" i18n="@@shell.footer.col.pages.about">About</a>
-          <a routerLink="/dashboard" i18n="@@shell.footer.col.pages.dashboard">Dashboard</a>
-          <a routerLink="/agents" i18n="@@shell.footer.col.pages.agents">Agents</a>
-          <a routerLink="/privacy" i18n="@@shell.footer.col.pages.privacy">Privacy</a>
-          <a routerLink="/support" i18n="@@shell.footer.col.pages.support">Support</a>
+    @if (!isStatsRoute) {
+      <div class="footer-inner">
+        <div class="footer-brand">
+
+          <img src="assets/icon48.png" i18n-alt="@@shell.footer.brand.logo.alt" alt="FSB" width="28" height="28" loading="lazy" decoding="async">
+          <span i18n="@@shell.footer.brand.text" [attr.translate]="'no'">FSB</span>
         </div>
-        <div class="footer-column">
-          <h4 i18n="@@shell.footer.col.project.title">Project</h4>
-           
-          <a href="https://github.com/lakshmanturlapati/FSB" target="_blank" rel="noopener" i18n="@@shell.footer.project.github" [attr.translate]="'no'">GitHub</a>
-           
-          <a href="https://github.com/lakshmanturlapati/FSB/issues" target="_blank" rel="noopener" i18n="@@shell.footer.project.issues" [attr.translate]="'no'">Issues</a>
-           
-          <a href="https://github.com/lakshmanturlapati/FSB/blob/main/LICENSE" target="_blank" rel="noopener" i18n="@@shell.footer.project.license">BSL 1.1 License</a>
-          <a routerLink="/stats" i18n="@@shell.footer.project.stats">Stats</a>
+        <div class="footer-links">
+          <div class="footer-column">
+            <h4 i18n="@@shell.footer.col.pages.title">Pages</h4>
+            <a routerLink="/" i18n="@@shell.footer.col.pages.home">Home</a>
+            <a routerLink="/about" i18n="@@shell.footer.col.pages.about">About</a>
+            <a routerLink="/dashboard" i18n="@@shell.footer.col.pages.dashboard">Dashboard</a>
+            <a routerLink="/agents" i18n="@@shell.footer.col.pages.agents">Agents</a>
+            <a routerLink="/privacy" i18n="@@shell.footer.col.pages.privacy">Privacy</a>
+            <a routerLink="/support" i18n="@@shell.footer.col.pages.support">Support</a>
+          </div>
+          <div class="footer-column">
+            <h4 i18n="@@shell.footer.col.project.title">Project</h4>
+
+            <a href="https://github.com/lakshmanturlapati/FSB" target="_blank" rel="noopener" i18n="@@shell.footer.project.github" [attr.translate]="'no'">GitHub</a>
+
+            <a href="https://github.com/lakshmanturlapati/FSB/issues" target="_blank" rel="noopener" i18n="@@shell.footer.project.issues" [attr.translate]="'no'">Issues</a>
+
+            <a href="https://github.com/lakshmanturlapati/FSB/blob/main/LICENSE" target="_blank" rel="noopener" i18n="@@shell.footer.project.license">BSL 1.1 License</a>
+            <a routerLink="/stats" i18n="@@shell.footer.project.stats">Stats</a>
+          </div>
         </div>
       </div>
-    </div>
+    }
     <div class="footer-bottom">
       <p i18n="@@shell.footer.bottom.credit">Made by <span [attr.translate]="'no'">Lakshman Turlapati</span></p>
       <p i18n="@@shell.footer.bottom.version"><span [attr.translate]="'no'">FSB</span> v{{ appVersion }}</p>

--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
@@ -1,6 +1,6 @@
 @if (isStatsRoute) {
   <div class="stats-glow-bg" aria-hidden="true"></div>
-  <button type="button" class="stats-back-btn" (click)="goBack()" aria-label="Go back">
+  <button type="button" class="stats-back-btn" (click)="goBack()" i18n-aria-label="@@shell.stats.back.aria" aria-label="Go back">
     <i class="ph ph-arrow-left"></i>
   </button>
 }

--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
@@ -359,3 +359,90 @@
     display: none !important;
   }
 }
+
+/* =============================================
+   Quick task 260526-ezk -- /stats-only chrome.
+   Append-only block; all rules are gated by the
+   ShowcaseShellComponent.isStatsRoute signal at
+   the template level, so nothing here can affect
+   any other route. Renamed keyframes (statsGlow)
+   to avoid colliding with home's heroGlow --
+   Angular emulated encapsulation does NOT scope
+   @keyframes (they leak globally).
+   ============================================= */
+
+/* Minimal back button -- mirrors .theme-toggle-btn's circular border-only
+   treatment for visual consistency. Position-fixed top-left so it sits in
+   the space the now-hidden <nav> used to occupy. */
+.stats-back-btn {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  z-index: 1000;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.stats-back-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+  transform: scale(1.1);
+}
+
+@media (max-width: 480px) {
+  .stats-back-btn {
+    top: 12px;
+    left: 12px;
+  }
+}
+
+/* Subtle orange aurora background -- mirrors home-page .hero-bg exactly
+   (same rgba color stops, same 12s timing). Position-fixed + inset:0 so it
+   covers the entire viewport; z-index:0 + main.stats-main z-index:1 keeps
+   it behind page content; pointer-events:none guarantees zero click
+   interference. */
+@keyframes statsGlow {
+  0%, 100% { transform: scale(1) translate(0, 0); opacity: 1; }
+  33%      { transform: scale(1.08) translate(2%, -3%); opacity: 0.85; }
+  66%      { transform: scale(0.95) translate(-2%, 2%); opacity: 0.9; }
+}
+
+.stats-glow-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 20%, rgba(255, 107, 53, 0.18) 0%, transparent 70%),
+    radial-gradient(ellipse 50% 40% at 80% 80%, rgba(255, 140, 66, 0.12) 0%, transparent 60%);
+  animation: statsGlow 12s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stats-glow-bg {
+    animation: none;
+  }
+}
+
+/* Stacking-context lift for the /stats <main>. The glow sits at z-index:0
+   on a fixed-position element, which would otherwise paint over normal
+   block-flow page content (which defaults to z-index:auto on a static
+   parent). Setting position:relative + z-index:1 on main.stats-main
+   creates a new stacking context above the glow without disturbing the
+   default <main> layout on any other route. */
+:host > main.stats-main {
+  position: relative;
+  z-index: 1;
+}

--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.ts
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.ts
@@ -1,5 +1,7 @@
 import { Component, HostListener, inject } from '@angular/core';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import { Location } from '@angular/common';
+import { NavigationEnd, Router, RouterLink, RouterLinkActive } from '@angular/router';
+import { filter } from 'rxjs/operators';
 import { APP_VERSION } from '../../core/seo/version';
 import { ThemeService } from '../../core/theme.service';
 import { LanguagePickerComponent } from '../language-picker/language-picker.component';
@@ -13,9 +15,58 @@ import { LanguagePickerComponent } from '../language-picker/language-picker.comp
 })
 export class ShowcaseShellComponent {
   private themeService = inject(ThemeService);
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
   readonly appVersion = APP_VERSION;
   mobileMenuOpen = false;
   navScrolled = false;
+
+  // Quick task 260526-ezk -- /stats-only chrome swap.
+  // isStatsRoute drives three conditional renders in the template:
+  //   1. hide global <nav> + .nav-mobile when true
+  //   2. hide .footer-inner (brand + columns) when true
+  //   3. show .stats-back-btn + .stats-glow-bg when true
+  // Every other route remains visually and behaviorally identical -- the
+  // blast radius is exactly one signal.
+  isStatsRoute = false;
+  // Counts in-app NavigationEnds so goBack() knows whether to call
+  // location.back() (when there's actual in-app history to pop) or fall
+  // back to router.navigate(['/']) (when /stats was opened as a deep link
+  // in a fresh tab and there's no prior in-app navigation to return to).
+  private navigationCount = 0;
+
+  constructor() {
+    // Seed isStatsRoute synchronously from the current URL so SSR /
+    // pre-hydration renders the correct chrome on the first paint.
+    this.isStatsRoute = this.matchesStatsRoute(this.router.url);
+
+    // Drive isStatsRoute + navigation-history counter from NavigationEnd.
+    this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(e => {
+        this.navigationCount++;
+        this.isStatsRoute = this.matchesStatsRoute(e.urlAfterRedirects);
+      });
+  }
+
+  private matchesStatsRoute(url: string): boolean {
+    const path = url.split('?')[0].split('#')[0];
+    // Match both `/stats` and any future `/<locale>/stats` shape, while
+    // ignoring query/hash. `endsWith` is safe here because no other route
+    // in app.routes.ts ends with `/stats`.
+    return path === '/stats' || path.endsWith('/stats');
+  }
+
+  goBack(): void {
+    if (this.navigationCount > 1) {
+      // Initial /stats land counts as navigation #1; any value above 1
+      // means at least one prior in-app navigation exists, so popping
+      // history lands somewhere inside the app rather than escaping it.
+      this.location.back();
+    } else {
+      this.router.navigate(['/']);
+    }
+  }
 
   get isDark(): boolean {
     return this.themeService.isDark();

--- a/showcase/angular/src/locale/messages.de.xlf
+++ b/showcase/angular/src/locale/messages.de.xlf
@@ -18,6 +18,14 @@
           <context context-type="linenumber">10,12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="shell.stats.back.aria" datatype="html">
+        <source>Go back</source>
+        <target state="translated">Zurück</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
+          <context context-type="linenumber">3,4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="shell.nav.brand.logo.alt" datatype="html">
         <source>FSB Logo</source>
         <target state="translated">FSB-Logo</target>

--- a/showcase/angular/src/locale/messages.es.xlf
+++ b/showcase/angular/src/locale/messages.es.xlf
@@ -18,6 +18,14 @@
           <context context-type="linenumber">10,12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="shell.stats.back.aria" datatype="html">
+        <source>Go back</source>
+        <target state="translated">Volver</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
+          <context context-type="linenumber">3,4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="shell.nav.brand.logo.alt" datatype="html">
         <source>FSB Logo</source>
         <target state="translated">Logotipo de FSB</target>

--- a/showcase/angular/src/locale/messages.ja.xlf
+++ b/showcase/angular/src/locale/messages.ja.xlf
@@ -18,6 +18,14 @@
           <context context-type="linenumber">10,12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="shell.stats.back.aria" datatype="html">
+        <source>Go back</source>
+        <target state="translated">戻る</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
+          <context context-type="linenumber">3,4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="shell.nav.brand.logo.alt" datatype="html">
         <source>FSB Logo</source>
         <target state="translated">FSB ロゴ</target>

--- a/showcase/angular/src/locale/messages.xlf
+++ b/showcase/angular/src/locale/messages.xlf
@@ -16,242 +16,249 @@
           <context context-type="linenumber">10,12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="shell.stats.back.aria" datatype="html">
+        <source>Go back</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
+          <context context-type="linenumber">3,4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="shell.nav.brand.logo.alt" datatype="html">
         <source>FSB Logo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">5</context>
+          <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.brand.text" datatype="html">
         <source>FSB</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">6,8</context>
+          <context context-type="linenumber">14,16</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.desktop.home" datatype="html">
         <source>Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.desktop.about" datatype="html">
         <source>About</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">10,11</context>
+          <context context-type="linenumber">18,19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.desktop.agents" datatype="html">
         <source>Agents</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">11,12</context>
+          <context context-type="linenumber">19,20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.desktop.dashboard" datatype="html">
         <source>Dashboard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">12,13</context>
+          <context context-type="linenumber">20,21</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.desktop.privacy" datatype="html">
         <source>Privacy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">13,14</context>
+          <context context-type="linenumber">21,22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.desktop.support" datatype="html">
         <source>Support</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">14,16</context>
+          <context context-type="linenumber">22,24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.desktop.github" datatype="html">
         <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i class=&quot;fa-brands fa-github&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> GitHub </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">19,21</context>
+          <context context-type="linenumber">27,29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.toggle.aria" datatype="html">
         <source>Toggle navigation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">22,23</context>
+          <context context-type="linenumber">30,31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.mobile.home" datatype="html">
         <source>Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.mobile.about" datatype="html">
         <source>About</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">31,32</context>
+          <context context-type="linenumber">39,40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.mobile.agents" datatype="html">
         <source>Agents</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">32,33</context>
+          <context context-type="linenumber">40,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.mobile.dashboard" datatype="html">
         <source>Dashboard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">33,34</context>
+          <context context-type="linenumber">41,42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.mobile.privacy" datatype="html">
         <source>Privacy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">34,35</context>
+          <context context-type="linenumber">42,43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.mobile.support" datatype="html">
         <source>Support</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">35,37</context>
+          <context context-type="linenumber">43,45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.nav.mobile.github" datatype="html">
         <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i class=&quot;fa-brands fa-github&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> GitHub</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">37,41</context>
+          <context context-type="linenumber">45,49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.brand.logo.alt" datatype="html">
         <source>FSB</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.brand.text" datatype="html">
         <source>FSB</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">50,52</context>
+          <context context-type="linenumber">60,62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.pages.title" datatype="html">
         <source>Pages</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">54,55</context>
+          <context context-type="linenumber">64,65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.pages.home" datatype="html">
         <source>Home</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.pages.about" datatype="html">
         <source>About</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">56,57</context>
+          <context context-type="linenumber">66,67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.pages.dashboard" datatype="html">
         <source>Dashboard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">57,58</context>
+          <context context-type="linenumber">67,68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.pages.agents" datatype="html">
         <source>Agents</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">58,59</context>
+          <context context-type="linenumber">68,69</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.pages.privacy" datatype="html">
         <source>Privacy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">59,60</context>
+          <context context-type="linenumber">69,70</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.pages.support" datatype="html">
         <source>Support</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">60,62</context>
+          <context context-type="linenumber">70,72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.col.project.title" datatype="html">
         <source>Project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">63,65</context>
+          <context context-type="linenumber">73,75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.project.github" datatype="html">
         <source>GitHub</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">75,77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.project.issues" datatype="html">
         <source>Issues</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">67,69</context>
+          <context context-type="linenumber">77,79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.project.license" datatype="html">
         <source>BSL 1.1 License</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">69,70</context>
+          <context context-type="linenumber">79,80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.project.stats" datatype="html">
         <source>Stats</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">70,73</context>
+          <context context-type="linenumber">80,83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.bottom.credit" datatype="html">
         <source>Made by <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>Lakshman Turlapati<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">75,76</context>
+          <context context-type="linenumber">86,87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.footer.bottom.version" datatype="html">
         <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span [attr.translate]=&quot;&apos;no&apos;&quot;&gt;"/>FSB<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> v<x id="INTERPOLATION" equiv-text="{{ appVersion }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">76,77</context>
+          <context context-type="linenumber">87,88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="shell.theme.toggle.aria" datatype="html">
         <source>Toggle theme</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
-          <context context-type="linenumber">82,83</context>
+          <context context-type="linenumber">93,94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="about.hero.title" datatype="html">

--- a/showcase/angular/src/locale/messages.zh-CN.xlf
+++ b/showcase/angular/src/locale/messages.zh-CN.xlf
@@ -18,6 +18,14 @@
           <context context-type="linenumber">10,12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="shell.stats.back.aria" datatype="html">
+        <source>Go back</source>
+        <target state="translated">返回</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
+          <context context-type="linenumber">3,4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="shell.nav.brand.logo.alt" datatype="html">
         <source>FSB Logo</source>
         <target state="translated">FSB 标志</target>

--- a/showcase/angular/src/locale/messages.zh-TW.xlf
+++ b/showcase/angular/src/locale/messages.zh-TW.xlf
@@ -18,6 +18,14 @@
           <context context-type="linenumber">10,12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="shell.stats.back.aria" datatype="html">
+        <source>Go back</source>
+        <target state="translated">返回</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/showcase-shell/showcase-shell.component.html</context>
+          <context context-type="linenumber">3,4</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="shell.nav.brand.logo.alt" datatype="html">
         <source>FSB Logo</source>
         <target state="translated">FSB 標誌</target>


### PR DESCRIPTION
## Summary

Aesthetic overhaul of `/stats` (showcase), scoped strictly to that route — zero bleed to home, agents, dashboard, etc.

- **Hide navbar on /stats**, replace with a minimal top-left back button (`Location.back()` when in-app navigation history exists, fallback to `/` for deep-link entry).
- **Minimize footer on /stats** — keeps only "Made by Lakshman Turlapati", "FSB v0.9.72", and the language picker. Hides the brand block and Pages / Project columns.
- **Add subtle orange glow background on /stats** — mirrors the home hero's `rgba(255,107,53,0.18)` + `rgba(255,140,66,0.12)` radial gradients + 12s ease-in-out animation. Same intensity, not amplified.

All three are driven from a single `isStatsRoute` signal in `ShowcaseShellComponent` — no new component, no global CSS, no fork of the footer.

## Implementation notes

- `isStatsRoute` derives from a `NavigationEnd` subscription using `urlNoQs.endsWith('/stats')` (forward-compatible with future locale prefixes like `/fr/stats`).
- Back-button fallback uses an in-app `navigationCount` (not `window.history.length`, which is polluted by pre-app history).
- Glow keyframes renamed `statsGlow` (not `heroGlow`) because Angular's emulated encapsulation does **not** scope `@keyframes` — same-named keyframes across components collide globally.
- `<main>` gets `[class.stats-main]` with `position:relative; z-index:1` so content stacks above the `z-index:0` glow on /stats only.

## Test plan

- [ ] Visit `/stats`: nav hidden, back button visible top-left, orange glow visible behind charts, footer shows only credit + version + language picker.
- [ ] Click back button from `/stats` reached via in-app nav → returns to previous page.
- [ ] Open `/stats` directly (fresh tab / deep link) → back button falls back to `/`.
- [ ] Visit `/`, `/agents`, `/dashboard`, `/about`, `/privacy`, `/support`: nav visible, full footer renders with both columns, no orange glow appears.
- [x] `npm run build` (showcase/angular) — exit 0, 30 routes prerendered, zero errors.