### PR TITLE
fix(stats): prevent glow edge-crop during animation + drop minimized-footer divider lines

### DIFF
--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html
@@ -50,7 +50,7 @@
   <ng-content></ng-content>
 </main>
 
-<footer class="footer">
+<footer class="footer" [class.stats-footer]="isStatsRoute">
   <div class="container">
     @if (!isStatsRoute) {
       <div class="footer-inner">

--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
@@ -457,3 +457,17 @@
   position: relative;
   z-index: 1;
 }
+
+/* /stats-only: drop both divider lines around the minimized footer (the
+   outer .footer border-top that separates page from footer, and the inner
+   .footer-bottom border-top that was originally the column-row separator).
+   With .footer-inner hidden on /stats, both lines become stray artifacts
+   above the credit/version/lang row. Other routes keep both dividers. */
+.footer.stats-footer {
+  border-top: none;
+}
+
+.footer.stats-footer .footer-bottom {
+  border-top: none;
+  padding-top: 0;
+}

--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
@@ -409,10 +409,21 @@
 }
 
 /* Subtle orange aurora background -- mirrors home-page .hero-bg exactly
-   (same rgba color stops, same 12s timing). Position-fixed + inset:0 so it
-   covers the entire viewport; z-index:0 + main.stats-main z-index:1 keeps
-   it behind page content; pointer-events:none guarantees zero click
-   interference. */
+   (same rgba color stops, same 12s timing). Position-fixed so it covers
+   the entire viewport; z-index:0 + main.stats-main z-index:1 keeps it
+   behind page content; pointer-events:none guarantees zero click
+   interference.
+
+   Edge-bleed note: home's .hero-bg is position:absolute inside a parent
+   .hero container with overflow:hidden + min-height:100vh, so the parent
+   masks the animated edges. Here .stats-glow-bg is position:fixed with no
+   clipping parent, so we instead oversize via inset:-10%. Without that,
+   the 66% keyframe (scale 0.95 + translate(-2%, 2%)) shrinks the element
+   inside the viewport AND shifts it down, exposing a sharp horizontal line
+   at the top edge where the still-tinted gradient meets the dark body bg.
+   With inset:-10% the element is 120% of the viewport in each dimension
+   and centered around it, so the worst-case shrunk + shifted edges stay
+   safely off-screen throughout the loop. */
 @keyframes statsGlow {
   0%, 100% { transform: scale(1) translate(0, 0); opacity: 1; }
   33%      { transform: scale(1.08) translate(2%, -3%); opacity: 0.85; }
@@ -421,7 +432,7 @@
 
 .stats-glow-bg {
   position: fixed;
-  inset: 0;
+  inset: -10%;
   z-index: 0;
   pointer-events: none;
   background:


### PR DESCRIPTION
Two small follow-ups on top of PR #82 (the /stats aesthetic overhaul), both scoped strictly to `/stats` — zero bleed to other routes.

## Summary

### 1. Fix glow animation edge-crop (`6bb1fff4`)

On production `/stats` the orange aurora glow had a visible visual bug: at the 66% mark of the 12s animation loop, a sharp horizontal line appeared at the top of the viewport — pure dark body above, gradient below.

**Root cause:** `.stats-glow-bg` is `position: fixed; inset: 0` (viewport-flush), and the 66% keyframe applies `scale(0.95) translate(-2%, 2%)`. The element shrinks below viewport size AND shifts down, pulling its top edge ~4.5% into the viewport. Because the radial gradient still has non-zero opacity at the element's edge (it only fades to transparent at 70% of the ellipse radius), the box boundary renders as a hard horizontal line where the still-tinted gradient meets the dark body background.

Home's `.hero-bg` (which `.stats-glow-bg` mirrors) avoids this only because it's `position: absolute` inside a `.hero` parent with `overflow: hidden + min-height: 100vh` — that parent clips the animated edges. `.stats-glow-bg` has no such clipping parent.

**Fix:** Change `inset: 0` → `inset: -10%` so the fixed element is 120% × 120% of viewport, centered around it. Worst-case shrunk+shifted edges now land ~7% off-screen on all sides, so the artifact never enters the viewport. Comment block expanded with the edge-bleed rationale so the divergence from home is documented. Scope: `.stats-glow-bg` only — `.hero-bg` and `@keyframes heroGlow` untouched.

### 2. Drop divider lines around the minimized footer (`9c53db25`)

With `.footer-inner` hidden on `/stats`, the `.footer { border-top }` and `.footer-bottom { border-top + padding-top: 24px }` rules left two stray horizontal lines and extra space above the credit/version/lang row. Gated a `.stats-footer` class on the `<footer>` via `[class.stats-footer]="isStatsRoute"`; scoped SCSS overrides zero out both `border-top`s plus the inner `padding-top`. Other routes keep both dividers and original spacing.

## Test plan

- [ ] `/stats` — orange glow animates smoothly with no sharp top/edge line at any point in the 12s loop; footer is the credit/version/lang row with no horizontal divider lines above it.
- [ ] `/` (home) — hero glow looks identical to before (no regression to `.hero-bg`); page-to-footer divider still visible; footer columns still present with their internal divider.
- [ ] `/about`, `/agents`, `/dashboard`, `/privacy`, `/support` — full footer renders unchanged with both column block and divider lines.
- [x] `npm run build` — green, 30 routes prerendered, zero errors.
- [x] `npm run lint:i18n` — 0 errors.
- [x] `ng extract-i18n` — no diff against committed `messages.xlf`.