### PR TITLE
fix(stats): make footer background transparent for seamless screen

### DIFF
--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss
@@ -458,13 +458,19 @@
   z-index: 1;
 }
 
-/* /stats-only: drop both divider lines around the minimized footer (the
-   outer .footer border-top that separates page from footer, and the inner
-   .footer-bottom border-top that was originally the column-row separator).
-   With .footer-inner hidden on /stats, both lines become stray artifacts
-   above the credit/version/lang row. Other routes keep both dividers. */
+/* /stats-only: make the footer seamless with the rest of the page.
+     - border-top: none drops the outer divider (page→footer line)
+     - background: transparent lets the fixed-position .stats-glow-bg show
+       through, AND lets the body background flow continuously through the
+       footer area instead of a visible darker --bg-card band
+     - .footer-bottom border-top + padding-top zero out the inner divider
+       and the spacing reserved for it (it was sized for the now-hidden
+       column block above)
+   Other routes keep both dividers, the card background, and the original
+   spacing. */
 .footer.stats-footer {
   border-top: none;
+  background: transparent;
 }
 
 .footer.stats-footer .footer-bottom {


### PR DESCRIPTION
Small follow-up on PR #83. With the divider line removed and the page using the orange glow as its background, the `.footer`'s own `background: var(--bg-card)` was rendering as a darker horizontal band at the bottom of `/stats`, breaking visual continuity with the rest of the page.

## Root cause

`.footer` carries `background: var(--bg-card)`, which sits above the `position: fixed` `.stats-glow-bg` at z-index 0. Even after dropping the divider in PR #83, the footer's opaque card-color background masked the glow underneath and produced a visible "burn" — a slightly-darker rectangular band at the bottom of the viewport.

## Fix

Add `background: transparent` to the `.stats-footer` SCSS override so:
- the glow flows continuously through the footer area, and
- the body background flows continuously through it too,

producing one seamless screen. Scope: `.stats-footer` only — other routes keep the card background unchanged.

## Test plan

- [ ] `/stats` — chart area and footer share the same background; no visible horizontal band/burn separating them; glow visibly continues through the footer area.
- [ ] `/`, `/about`, `/agents`, `/dashboard`, `/privacy`, `/support` — footer still has its solid card background; visually unchanged from current production.
- [x] `npm run build` — green, 30 routes prerendered, 0 errors.
- [x] `npm run lint:i18n` — 0 errors.
- [x] `ng extract-i18n` — no diff against committed `messages.xlf`.