### PR TITLE
fix(stats): render Agents-running sparkline immediately on first paint

### DIFF
--- a/showcase/angular/src/app/pages/stats/stats-page.component.ts
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.ts
@@ -1029,17 +1029,31 @@ export class StatsPageComponent implements OnInit, AfterViewInit, OnDestroy {
         // 288 samples = 24h @ 5-min poll). slice() copies so Chart.js can't
         // mutate the canonical buffer. Axes hidden so the line reads as a
         // sparkline; bucket label still appears in the legend for context.
+        //
+        // First-paint warmup (bug fix 260527): the ring buffer starts empty
+        // and only grows by one sample per 5-min poll. A 1-point line dataset
+        // with pointRadius:0 draws NOTHING -- Chart.js needs >=2 points to
+        // stroke a line, and we hide point markers for the sparkline aesthetic.
+        // Result: the canvas was visually empty for ~5 minutes after page load
+        // until the second poll arrived. Fix: when ring.length < 2, synthesize
+        // a 2-point flat-line dataset at the current `active_agents_now`
+        // headline value so the chart immediately reads as "currently N agents"
+        // and gains real shape as the ring fills with subsequent samples. The
+        // ring buffer itself is untouched -- this is a render-time fallback
+        // scoped strictly to this case.
         const headline = this.latestFsbHeadline;
         const bucket = headline?.active_agents_bucket ?? '0';
         const ring = this.agentHistoryRing.slice();
+        const live = headline?.active_agents_now ?? 0;
+        const data = ring.length >= 2 ? ring : [live, live];
         return {
           type: 'line',
           data: {
-            labels: ring.map((_, i) => String(i)),
+            labels: data.map((_, i) => String(i)),
             datasets: [
               {
                 label: $localize`:@@SHOWCASE_STATS_FSB_CHART_AGENTS_RUNNING_LEGEND:Active agents (10 min window)` + ` [${bucket}]`,
-                data: ring,
+                data,
                 borderColor: tokens.primary,
                 backgroundColor: tokens.primarySoft,
                 fill: true,

--- a/showcase/angular/src/app/pages/stats/stats-page.component.ts
+++ b/showcase/angular/src/app/pages/stats/stats-page.component.ts
@@ -1035,17 +1035,26 @@ export class StatsPageComponent implements OnInit, AfterViewInit, OnDestroy {
         // with pointRadius:0 draws NOTHING -- Chart.js needs >=2 points to
         // stroke a line, and we hide point markers for the sparkline aesthetic.
         // Result: the canvas was visually empty for ~5 minutes after page load
-        // until the second poll arrived. Fix: when ring.length < 2, synthesize
-        // a 2-point flat-line dataset at the current `active_agents_now`
-        // headline value so the chart immediately reads as "currently N agents"
-        // and gains real shape as the ring fills with subsequent samples. The
-        // ring buffer itself is untouched -- this is a render-time fallback
-        // scoped strictly to this case.
+        // until the second poll arrived. Fix: when ring.length < 2 AND we have
+        // a real FSB headline, synthesize a 2-point flat-line dataset at the
+        // current `active_agents_now` value so the chart immediately reads as
+        // "currently N agents" and gains real shape as the ring fills.
+        //
+        // Gate on `headline` (per Codex P2 review): GitHub datasets can flip
+        // viewState to 'ready' before the FSB headline endpoint resolves (or
+        // when it errors). Without this gate, the fallback would draw a
+        // misleading [0, 0] flat-zero line during that window -- as if there
+        // were genuinely zero active agents. Better to render an empty canvas
+        // (honest "no data yet") until at least one real FSB sample arrives.
+        // Note: onFsbHeadlineUpdate assigns `latestFsbHeadline` and pushes onto
+        // the ring atomically, so `headline !== null` implies `ring.length >= 1`.
         const headline = this.latestFsbHeadline;
         const bucket = headline?.active_agents_bucket ?? '0';
         const ring = this.agentHistoryRing.slice();
         const live = headline?.active_agents_now ?? 0;
-        const data = ring.length >= 2 ? ring : [live, live];
+        const data = !headline
+          ? []
+          : ring.length >= 2 ? ring : [live, live];
         return {
           type: 'line',
           data: {

--- a/showcase/angular/src/locale/messages.xlf
+++ b/showcase/angular/src/locale/messages.xlf
@@ -3030,28 +3030,28 @@
         <source>Active agents (10 min window)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1041</context>
+          <context context-type="linenumber">1055</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_PENDING_MCP" datatype="html">
         <source>Pending (k&gt;=5 floor)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1070</context>
+          <context context-type="linenumber">1084</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_POPULAR_AGENTS_LEGEND" datatype="html">
         <source>Popular agents</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1077</context>
+          <context context-type="linenumber">1091</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_AVG_AGENTS_LEGEND" datatype="html">
         <source>Avg agents per active user (last 30 days)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1109</context>
+          <context context-type="linenumber">1123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="support.hero.title" datatype="html">

--- a/showcase/angular/src/locale/messages.xlf
+++ b/showcase/angular/src/locale/messages.xlf
@@ -3030,28 +3030,28 @@
         <source>Active agents (10 min window)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1055</context>
+          <context context-type="linenumber">1064</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_PENDING_MCP" datatype="html">
         <source>Pending (k&gt;=5 floor)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1084</context>
+          <context context-type="linenumber">1093</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_POPULAR_AGENTS_LEGEND" datatype="html">
         <source>Popular agents</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1091</context>
+          <context context-type="linenumber">1100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="SHOWCASE_STATS_FSB_CHART_AVG_AGENTS_LEGEND" datatype="html">
         <source>Avg agents per active user (last 30 days)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/stats/stats-page.component.ts</context>
-          <context context-type="linenumber">1123</context>
+          <context context-type="linenumber">1132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="support.hero.title" datatype="html">


### PR DESCRIPTION
## Summary

- **Bug:** Visitors landed on `/stats`, switched to the "Agents running" tab, and saw a 360px black void for ~5 minutes before any line appeared. Headline row above ("20 active agents · 15,844 lifetime agents") populated instantly, so the network was healthy — only the chart canvas was empty.
- **Root cause:** `agentHistoryRing` is a component-local buffer that starts empty on every mount. `FSBTelemetryService` polls every 5 min (`POLL_INTERVAL_MS = 5 * 60 * 1000`) and `start()` only fires ONE immediate refresh. So the ring had exactly 1 sample for the first 5 min. The `fsb-agents-running` chart config uses `pointRadius: 0` (sparkline aesthetic), and Chart.js needs ≥2 points to stroke a line — a 1-point dataset with invisible points draws nothing.
- **Fix:** Render-time fallback inside the `fsb-agents-running` switch case only — when `ring.length < 2`, synthesize `[live, live]` from the current `active_agents_now` headline value so the chart draws an immediate flat "currently N agents" line that gains real shape as the ring fills with subsequent samples.

## Constraints respected

- Scoped strictly to lines 1029-1059 of `stats-page.component.ts` (the `fsb-agents-running` switch arm).
- Polling cadence in `FSBTelemetryService` untouched (out of scope; that's a privacy/cost-of-egress decision).
- `agentHistoryRing` buffer untouched — no pre-seed, no localStorage, no shared service state.
- Legend i18n marker `SHOWCASE_STATS_FSB_CHART_AGENTS_RUNNING_LEGEND` byte-identical.
- No other tab's chart config touched.
- When `ring.length >= 2`, behavior is byte-identical to pre-fix.
- `messages.xlf` line-number context drift regenerated via `ng extract-i18n` so the CI "no diff" gate stays green.

## Test plan

- [x] `cd showcase/angular && npm run build` — passes (11s, 30 routes prerendered).
- [x] `npm run lint:i18n` — 0 errors (one pre-existing unrelated warning on agents-page).
- [x] `npx ng extract-i18n` — only line-number context drift, no new/removed trans-units, no source text changes; regenerated file committed.
- [ ] Manual: visit deployed `/stats`, click "Agents running" tab, confirm a flat horizontal line appears immediately at the current value (e.g. ~20 agents) instead of an empty 360px black void.
- [ ] Manual: wait through one 5-min poll cycle, confirm the line transitions naturally from flat to varying as the second real sample arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)