### PR TITLE
fix(stats): exclude heartbeats from popular_mcp + README polish

### DIFF
--- a/showcase/server/src/db/queries.js
+++ b/showcase/server/src/db/queries.js
@@ -181,9 +181,15 @@ class Queries {
     this.selectGlobalForDayRange = this.db.prepare(
       'SELECT COUNT(DISTINCT install_uuid) AS unique_installs, SUM(tokens_in) AS tokens_in_sum, SUM(tokens_out) AS tokens_out_sum, SUM(active_agent_count) AS agents_active_sum FROM telemetry_events WHERE ts_minute >= ? AND ts_minute < ?'
     );
-    this.selectPopularMcpForDayRange = this.db.prepare(
-      'SELECT mcp_client, COUNT(DISTINCT install_uuid) AS uniq FROM telemetry_events WHERE ts_minute >= ? AND ts_minute < ? GROUP BY mcp_client ORDER BY uniq DESC'
-    );
+    this.selectPopularMcpForDayRange = this.db.prepare(`
+      SELECT mcp_client, COUNT(DISTINCT install_uuid) AS uniq
+      FROM telemetry_events
+      WHERE ts_minute >= ? AND ts_minute < ?
+        -- exclude presence heartbeats from popularity ranking (see RCA 260530-19i)
+        AND NOT (tokens_in = 0 AND tokens_out = 0 AND mcp_client = 'unknown')
+      GROUP BY mcp_client
+      ORDER BY uniq DESC
+    `);
 
     this.selectTodaySalt = this.db.prepare('SELECT salt_hex, minted_at FROM telemetry_daily_salt WHERE day_utc = ?');
     this.insertTodaySalt = this.db.prepare('INSERT INTO telemetry_daily_salt (day_utc, salt_hex, minted_at) VALUES (?, ?, ?)');


### PR DESCRIPTION
## Summary

- **Stats fix** — `/stats` "Popular agents" tab was rendering a dominant `"unknown"` slice fed by PRESENCE-01 heartbeat rows emitted by idle installs (`extension/utils/telemetry-collector.js:587`, added 2026-05-24). Added a server-side SQL filter on `selectPopularMcpForDayRange` excluding `tokens_in=0 AND tokens_out=0 AND mcp_client='unknown'`. Heartbeats keep feeding `active_users_now` / `agents_active_sum` through separate aggregators (`activeTracker` and `selectGlobalForDayRange`) — only the popularity ranking is filtered. Server-side only: retroactively cleans existing aggregates on the next hourly housekeeper tick, no extension release required. Not a regression of `cd07d9b6` — the dispatcher fix is intact; this was a new sibling writer path. Full RCA preserved locally as `260530-19i`.
- **README polish** — root README rewritten (architecture updates, demo thumbnails, common use cases pitch, install/client naming guidance, showcase `/stats` mention); `mcp/README.md`, `extension/README.md`, `showcase/README.md` tightened to match.
- **i18n hygiene (from PR #86)** — Angular i18n source catalog refreshed, support FAQ locale placeholders repaired, stats removed from crawler metadata, CI i18n diff guard recorded.

Net diff: 5 files (`README.md`, `extension/README.md`, `mcp/README.md`, `showcase/README.md`, `showcase/server/src/db/queries.js`), +169 / −112.

## Test plan

Mirrors `ci.yml` (extension + mcp-smoke + website jobs):

- [x] Targeted: `tests/server-telemetry-housekeeper.test.js` — 25 / 0
- [x] Targeted: `tests/server-public-stats-{headline,series,cache,no-auth}.test.js` — 92 / 0
- [x] `npm run validate:extension` — manifest + 245 JS files OK
- [x] `npm test` — full extension+bridge contract suite, exit 0
- [x] `npm run test:mcp-smoke` — 84 / 0
- [x] `verify-locale-sync.mjs` — parity OK across 6 locales
- [x] `lint:i18n` — 0 errors (1 stale `eslint-disable` warning, non-blocking)
- [x] `ng extract-i18n` diff vs `messages.xlf` — clean (no drift)
- [x] `showcase/angular run build` — prerender + SSR exit 0
- [x] `verify:hreflang` — 301 / 0 (hreflang, canonical, html lang on all prerendered routes)
- [x] `verify-bundle-budgets.mjs` — all locales within gzipped budget