### PR TITLE
fix(showcase): allow SimpleIcons + Natural Earth hosts in CSP (broken catalog logos + globe)

### DIFF
--- a/showcase/server/server.js
+++ b/showcase/server/server.js
@@ -59,9 +59,15 @@ const SHOWCASE_CSP = [
   "script-src 'self' 'unsafe-inline' https://unpkg.com",
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://unpkg.com",
   "font-src 'self' data: https://cdnjs.cloudflare.com https://unpkg.com",
-  "img-src 'self' data: blob: https://i.ytimg.com",
+  // cdn.simpleicons.org serves the brand/tech logos in the home capability
+  // marquee (home-page.component simpleIcon()); i.ytimg.com is the /about
+  // YouTube thumbnails. Without simpleicons here every catalog logo is blocked.
+  "img-src 'self' data: blob: https://i.ytimg.com https://cdn.simpleicons.org",
   "media-src 'self' blob:",
-  "connect-src 'self'",
+  // raw.githubusercontent.com serves the Natural Earth land GeoJSON the stats
+  // globe fetches once per session (globe-visualization.service); without it the
+  // globe silently falls back to rough continents.
+  "connect-src 'self' https://raw.githubusercontent.com",
   // YouTube embeds on the /about page require frame-src; without this it falls
   // back to default-src 'self' and the demo videos render as a blocked iframe.
   "frame-src https://www.youtube.com https://www.youtube-nocookie.com",


### PR DESCRIPTION
## Problem

On the live showcase, every logo in the home **capability catalog / carousel** (and the native-handler cards) renders broken.

**Root cause:** `SHOWCASE_CSP` in `showcase/server/server.js` was not widened for two external hosts the v0.9.90 redesign introduced:

- **`img-src`** omitted `https://cdn.simpleicons.org` — the capability marquee builds logo URLs via `home-page.component` `simpleIcon()` (`https://cdn.simpleicons.org/{slug}/94a3b8`). 46+ logos on the home page alone were CSP-blocked. (The SimpleIcons SVGs serve fine — `200 image/svg+xml` — CSP was the only blocker.)
- **`connect-src`** omitted `https://raw.githubusercontent.com` — the stats globe fetches the Natural Earth land GeoJSON (`globe-visualization.service.ts`). Blocked → the globe silently falls back to `createRoughLandDots()` (rough continents) instead of precise coastlines.

Local `/assets/*` images were never affected (`'self'`).

## Fix

Add the two hosts to the respective directives. No code/behaviour change beyond unblocking the redesign's existing asset dependencies. No test pins `SHOWCASE_CSP`.

## Follow-up (not in this PR)

The globe's ~1 MB GeoJSON is fetched from a third-party `master`-branch raw URL at runtime — worth bundling locally later (`/assets/`, served same-origin) to drop the runtime dependency; that would also let `connect-src` stay `'self'`.