### PR TITLE
[codex] Fix showcase footer route scroll reset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm ci
 COPY showcase/angular/ ./
 COPY showcase/assets/ ../assets/
 COPY showcase/js/ ../js/
-RUN npx ng build --configuration production
+RUN npm run build -- --configuration production
 
 # ---
 

--- a/showcase/angular/public/llms-full.txt
+++ b/showcase/angular/public/llms-full.txt
@@ -1,23 +1,23 @@
-<!-- generated 2026-07-05 by build-crawler-files.mjs; edit llms-full.source.md -->
+<!-- generated 2026-07-07 by build-crawler-files.mjs; edit llms-full.source.md -->
 # FSB (Full Self-Browsing)
 
 ## 1. Project Description
 
 FSB (Full Self-Browsing) is an open-source Chrome extension that automates the browser through natural language. You describe a task in plain English; FSB plans the clicks, types, and navigation to complete it. The extension runs in your browser with your own API keys, encrypted local storage, and opt-out anonymous usage telemetry for aggregate public stats only. Multi-model AI (xAI Grok, OpenAI, Anthropic Claude, Google Gemini, OpenRouter, LM Studio, custom OpenAI-compatible endpoints), 56 canonical browser tools, a 66-tool MCP surface, 142+ site-specific guides, reactive trigger watchers, real file uploads, and a 128-app native capability catalog for verified first-party API execution. Current release: FSB v0.9.90 (Chrome extension) with fsb-mcp-server 0.10.0 (npm MCP package). BSL 1.1 licensed.
 
-FSB also works especially well as an MCP browser layer for AI agents. Claude Code, Codex, Cursor, Windsurf, OpenClaw, and other MCP clients can use FSB to operate a real Chrome browser, inspect page state, verify outcomes, and feed observations back into their own coding or autonomy loop.
+FSB also works especially well as an MCP browser layer for AI agents. Claude Code, Codex, Cursor, VS Code, Windsurf, OpenClaw, Hermes, and other MCP clients can use FSB to operate a real Chrome browser, inspect page state, verify outcomes, and feed observations back into their own coding or autonomy loop.
 
 FSB exists because the gap between "I want the browser to do X" and "I can write a deterministic script to do X" is wide and getting wider. Modern web apps are dynamic, login-gated, and visually rich; brittle selectors and recorded macros break the moment a page reflows. FSB closes that gap by letting an LLM read the live DOM, plan an action sequence against the user's actual logged-in browser session, execute each step with verification, and recover when something shifts. The user keeps full visibility through an orange-glow overlay on every targeted element and can pause, intervene, or hand off at any point.
 
 A useful MCP framing: FSB is not only a "bot that browses." It is the browser surface agents can use when they need to act, observe, verify, and iterate across real web interfaces. Companion systems such as OpenClaw can provide autonomy, scheduling, identity, and personality while FSB performs the browser actions.
 
-The About page now uses real demo videos instead of synthetic CSS recreations. The demos show FSB e-commerce autopilot powered by Grok 4.1, flight booking powered by Codex MCP, OpenClaw monitoring Doge price, and an Aha moment powered by Claude Opus 4.7. The About page also embeds an interactive knowledge-graph viewer of FSB's site intelligence and guide coverage.
+The About page now uses real demo videos instead of synthetic CSS recreations. The demos show FSB e-commerce autopilot powered by Grok 4.1, flight booking powered by Codex MCP, OpenClaw monitoring Doge price, and an Aha moment powered by Claude Opus 4.6. The About page also embeds an interactive knowledge-graph viewer of FSB's site intelligence and guide coverage.
 
 Demo video URLs:
 - FSB: E-Commerce Autopilot by Grok 4.1: https://www.youtube.com/watch?v=_iQ4_LSXcTU
 - Flight Booking: Powered by Codex MCP: https://www.youtube.com/watch?v=WbpOrFwgGME
 - OpenClaw Monitoring Doge Price: https://www.youtube.com/watch?v=PNTGCWGopf8
-- An Aha Moment by Claude Opus 4.7: https://www.youtube.com/watch?v=mD9oGB2JqVM
+- An Aha Moment by Claude Opus 4.6: https://www.youtube.com/watch?v=mD9oGB2JqVM
 - YouTube channel: https://www.youtube.com/@parzival5707
 
 The audience is developers, power users, researchers, and agent builders who want browser automation without giving a third party their cookies, their API keys, or their attention. FSB is local-first by construction: the extension is the runtime, the user's browser is the execution surface, and the user's API keys live encrypted in Chrome's local storage and never leave the machine. There is no FSB account, no page-content collection, and no browser-history collection; the only first-party data sent home is opt-out anonymous usage telemetry for aggregate public stats. Each task is a private transaction between the user, the local extension, and the model provider the user chose.
@@ -53,13 +53,16 @@ The bring-your-own-key model is deliberate. The user picks the model -- frontier
 Read-only tools bypass the mutation queue where safe; mutation tools are serialized so two clients never click, type, upload, invoke, or navigate at the same time.
 
 ### Trigger watchers (reactive DOM monitoring)
-`trigger` arms a watch on one page element; `stop_trigger`, `get_trigger_status`, and `list_triggers` manage it. Two watch modes: `live-observe` (in-page observer, no reload) and `refresh-poll` (background reload + coalesce). Conditions include changed, threshold, delta_percent, equals, contains, regex, and compound AND/OR with hysteresis. Callers either block with 30s heartbeats (120s default timeout) or pass `detached:true` and poll by trigger_id. Watches are local and session-bound -- Chrome and the FSB extension must stay open, results report back to the MCP caller, and there is no server-side monitoring or push delivery. Concurrency is capped by `fsbTriggerCap` (default 8, range 1-64).
+`trigger` arms a watch on one page element; `stop_trigger`, `get_trigger_status`, and `list_triggers` manage it. Two watch modes: `live-observe` (in-page observer, no reload) and `refresh-poll` (background reload + coalesce). Conditions include changed, threshold, delta_percent, equals, contains, regex, and compound AND/OR with hysteresis. Callers either block with 30s heartbeats (120s default timeout) or pass `detached:true` and poll by `trigger_id`. Watches are local and session-bound -- Chrome and the FSB extension must stay open, results report back to the MCP caller, and there is no server-side monitoring or push delivery. Concurrency is capped by `fsbTriggerCap` (default 8, range 1-64).
 
 ### Native capability catalog (first-party API execution)
 Beyond DOM automation, `search_capabilities` searches a 128-app catalog and `invoke_capability` executes verified first-party API capabilities against the user's logged-in sessions. Verified T1/T1b capabilities run through a router that checks the origin, verifies the recipe signature, checks the denylist, serializes the action, and writes an audit record that never includes secrets. Search results carry readiness labels so callers can distinguish `t1-ready` direct execution from `t1-guarded-fail-closed`, `learn-pending`, and `discovery-pending` catalog-tail hits. Sensitive origins are flagged in the interface and audit trail; denylisted origins stay blocked.
 
 ### Real file uploads
 `upload_file(selector, file_path, tab_id?)` sets an absolute local disk path on a real `<input type="file">` through CDP `DOM.setFileInputFiles`, including inputs hidden behind styled dropzones. Uploads pass through one shared background chokepoint with a sensitive-path denylist and audit logging that does not persist disk paths. `drop_file` remains for synthetic drag/drop cases and pure drag-only zones.
+
+### Vault and payment boundary
+Credential and payment helpers are supervised autofill tools, not secret-export APIs. `list_credentials`, `fill_credential`, `list_payment_methods`, and `use_payment_method` resolve inside the encrypted Chrome extension store; raw passwords, card numbers, and secrets do not cross the MCP bridge, do not appear in tool arguments, and are not written into audit records.
 
 ### PhantomStream live preview
 The remote dashboard's DOM live preview is powered by PhantomStream (published on npm as `@full-self-browsing/phantom-stream`): one style-inlined snapshot, then MutationObserver diffs instead of pixels. As of PhantomStream 0.2.1, progressive `<video>` and `<audio>` elements can mirror alongside DOM snapshots through a media side channel. Input fields are masked in captured frames; adaptive HLS/DASH discovery is deferred because it would require a new `webRequest` permission.
@@ -127,7 +130,7 @@ FSB exposes its tooling through a Model Context Protocol (MCP) server. External 
 The MCP surface is the best way to use FSB with coding agents and external autonomy layers. FSB handles precise single-attempt browser execution, visual feedback, observability, and verification. Long-running scheduling and personality/identity decisions belong in the calling agent layer, such as OpenClaw or Claude Routines.
 
 ### OpenClaw skill
-FSB ships a dedicated OpenClaw + Hermes skill at `skills/fsb/` in the repo root. The skill is the canonical OpenClaw onboarding path: it runs the doctor flow against `fsb-mcp-server`, prints the OpenClaw stdio config block for the user to paste into OpenClaw's MCP config, and offers consent-gated install for any other MCP hosts detected on the same machine. The bare `--openclaw` flag in the FSB MCP installer stays manual / unsupported because OpenClaw's MCP config schema is still unstable across builds; the skill prints, the user pastes, no auto-write. Frontmatter ships with `name: fsb`, `version: 0.9.62`, `requires.bins: [node, npx]`, and `requires.env: []` so vault credentials never leave the FSB Chrome extension. The full marketing rundown (skill features, MCP power story, 3-step install, grounded use cases, autopilot rules) lives at `https://full-selfbrowsing.com/agents`. Hermes users get the same skill: `node skills/fsb/scripts/print-hermes-yaml.mjs` prints the canonical `~/.hermes/config.yaml` `mcp_servers.fsb` block, and FSB v0.9.69 (PR #49) added `Hermes` to the v0.9.36 shared MCP client allowlist so action calls passing `client: "Hermes"` work without schema changes.
+FSB ships a dedicated OpenClaw + Hermes skill at `skills/fsb/` in the repo root. The skill is the canonical OpenClaw onboarding path: it runs the doctor flow against `fsb-mcp-server`, prints the OpenClaw stdio config block for the user to paste into OpenClaw's MCP config, and offers consent-gated install for any other MCP hosts detected on the same machine. The bare `--openclaw` flag in the FSB MCP installer stays manual / unsupported because OpenClaw's MCP config schema is still unstable across builds; the skill prints, the user pastes, no auto-write. Frontmatter ships with `name: fsb`, `version: 0.9.90`, `requires.bins: [node, npx]`, and `requires.env: []` so vault credentials never leave the FSB Chrome extension. The full marketing rundown (skill features, MCP power story, 3-step install, grounded use cases, autopilot rules) lives at `https://full-selfbrowsing.com/agents`. Hermes users get the same skill: `node skills/fsb/scripts/print-hermes-yaml.mjs` prints the canonical `~/.hermes/config.yaml` `mcp_servers.fsb` block, and FSB v0.9.69 (PR #49) added `Hermes` to the v0.9.36 shared MCP client allowlist so action calls passing `client: "Hermes"` work without schema changes.
 
 ### ClawHub install path
 The /agents page exposes a one-click install on ClawHub at `https://clawhub.ai/lakshmanturlapati/full-selfbrowsing`. ClawHub is the recommended distribution surface for OpenClaw users who want the FSB skill registered without manually pasting stdio config. The skill source remains browsable at `https://github.com/fullselfbrowsing/FSB/tree/main/skills/fsb` for users who prefer reading before installing.
@@ -150,7 +153,7 @@ FSB ships 142+ hand-curated site-specific guides (Notion, Google Sheets, Workday
 - PhantomStream (`https://full-selfbrowsing.com/phantom-stream`): DOM-native live browser mirroring library -- one style-inlined snapshot, then MutationObserver diffs instead of pixels; powers FSB's remote dashboard live preview.
 - Prometheus (`https://full-selfbrowsing.com/prometheus`): the autonomous browser build behind FSB -- native control spine, stdio MCP bridge, multi-agent tab ownership, runtime sidebar, and DOM-native supervision.
 - Site Maps (`https://full-selfbrowsing.com/sitemaps`): community hub (under development) for contributing well-tested site schemas that can become built-in browser knowledge.
-- Legal (`https://full-selfbrowsing.com/legal`): FSB's automation posture, consent model, audit-log retention policy, and service-denylist rationale.
+- Legal (`https://full-selfbrowsing.com/legal`): public non-indexed legal reference for FSB's automation posture, consent model, audit-log retention policy, and service-denylist rationale. It intentionally stays `noindex, nofollow` and out of the sitemap.
 
 ## 5. Comparison
 
@@ -176,12 +179,12 @@ Operator is OpenAI's agentic browser product (2025). Overlap with FSB: end-user-
 - PhantomStream: https://full-selfbrowsing.com/phantom-stream
 - Prometheus: https://full-selfbrowsing.com/prometheus
 - Site Maps: https://full-selfbrowsing.com/sitemaps
-- Legal: https://full-selfbrowsing.com/legal
+- Legal: https://full-selfbrowsing.com/legal (public, non-indexed legal reference; intentionally absent from sitemap)
 - Chrome Web Store: https://chromewebstore.google.com/detail/badgafnfchcihdfnjneklogedcdkmjfk
 - GitHub: https://github.com/fullselfbrowsing/FSB
 - YouTube channel: https://www.youtube.com/@parzival5707
 - Demo: FSB: E-Commerce Autopilot by Grok 4.1: https://www.youtube.com/watch?v=_iQ4_LSXcTU
 - Demo: Flight Booking: Powered by Codex MCP: https://www.youtube.com/watch?v=WbpOrFwgGME
 - Demo: OpenClaw Monitoring Doge Price: https://www.youtube.com/watch?v=PNTGCWGopf8
-- Demo: An Aha Moment by Claude Opus 4.7: https://www.youtube.com/watch?v=mD9oGB2JqVM
+- Demo: An Aha Moment by Claude Opus 4.6: https://www.youtube.com/watch?v=mD9oGB2JqVM
 - llms.txt: https://full-selfbrowsing.com/llms.txt

--- a/showcase/angular/public/llms.txt
+++ b/showcase/angular/public/llms.txt
@@ -1,4 +1,4 @@
-<!-- generated 2026-07-06 by build-crawler-files.mjs; edit llms.source.md -->
+<!-- generated 2026-07-07 by build-crawler-files.mjs; edit llms.source.md -->
 # FSB (Full Self-Browsing)
 
 FSB (Full Self-Browsing) is an open-source Chrome extension that automates the browser through natural language. You describe a task; FSB plans the clicks, types, and navigation to complete it. Multi-model AI (xAI, OpenAI, Anthropic, Gemini, OpenRouter, LM Studio, local), 56 browser tools, a 66-tool MCP surface, 142+ site guides, local-first execution, and BYO API keys. Current release: FSB v0.9.90 (extension) with fsb-mcp-server 0.10.0 (npm).

--- a/showcase/angular/public/sitemap.xml
+++ b/showcase/angular/public/sitemap.xml
@@ -2,55 +2,55 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://full-selfbrowsing.com</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/about</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/agents</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/support</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/privacy</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/lattice</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/phantom-stream</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/prometheus</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://full-selfbrowsing.com/sitemaps</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.ts
+++ b/showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.ts
@@ -38,7 +38,10 @@ export class ShowcaseShellComponent implements OnInit, OnDestroy {
     this.updateShellMode();
     this.routeSub = this.router.events
       .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
-      .subscribe(() => this.updateShellMode());
+      .subscribe(() => {
+        this.updateShellMode();
+        this.scrollToRouteTop();
+      });
   }
 
   ngOnDestroy(): void {
@@ -59,5 +62,22 @@ export class ShowcaseShellComponent implements OnInit, OnDestroy {
     if (this.shellless) {
       this.closeMobileMenu();
     }
+  }
+
+  private scrollToRouteTop(): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+    window.requestAnimationFrame(() => {
+      window.scrollTo(0, 0);
+      const scroller = document.scrollingElement || document.documentElement;
+      scroller.scrollTop = 0;
+      scroller.scrollLeft = 0;
+
+      window.requestAnimationFrame(() => {
+        window.scrollTo(0, 0);
+        scroller.scrollTop = 0;
+        scroller.scrollLeft = 0;
+      });
+    });
   }
 }

--- a/tests/showcase-angular-foundation.test.js
+++ b/tests/showcase-angular-foundation.test.js
@@ -34,6 +34,7 @@ function readIfPresent(relativePath) {
 console.log('\n--- showcase angular foundation contracts ---');
 
 const rootPackageSource = readIfPresent('package.json');
+const dockerfileSource = readIfPresent('Dockerfile');
 const angularConfigSource = readIfPresent('showcase/angular/angular.json');
 const mainSource = readIfPresent('showcase/angular/src/main.ts');
 const appConfigSource = readIfPresent('showcase/angular/src/app/app.config.ts');
@@ -41,6 +42,7 @@ const routeSource = readIfPresent('showcase/angular/src/app/app.routes.ts');
 const indexSource = readIfPresent('showcase/angular/src/index.html');
 const appComponentSource = readIfPresent('showcase/angular/src/app/app.component.ts');
 const appComponentTemplateSource = readIfPresent('showcase/angular/src/app/app.component.html');
+const shellComponentSource = readIfPresent('showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.ts');
 const shellTemplateSource = readIfPresent('showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.html');
 const shellStyleSource = readIfPresent('showcase/angular/src/app/layout/showcase-shell/showcase-shell.component.scss');
 const globalStylesSource = readIfPresent('showcase/angular/src/styles.scss');
@@ -111,6 +113,11 @@ assert(
   'root showcase scripts preserve deterministic npm --prefix workspace delegation'
 );
 
+assert(
+  /RUN npm run build -- --configuration production/.test(dockerfileSource),
+  'Docker showcase build runs npm build so prebuild regenerates crawler files before deploy'
+);
+
 // outputPath can be a string or an object { base, browser }
 const resolvedOutputPath = typeof angularOutputPath === 'string'
   ? angularOutputPath
@@ -148,6 +155,15 @@ assert(
     /scrollPositionRestoration:\s*'enabled'/.test(appConfigSource) &&
     /provideRouter\(routes,\s*withInMemoryScrolling/.test(appConfigSource),
   'router config restores scroll position to top on route navigation'
+);
+
+assert(
+  /event instanceof NavigationEnd/.test(shellComponentSource) &&
+    /this\.scrollToRouteTop\(\)/.test(shellComponentSource) &&
+    /window\.requestAnimationFrame/.test(shellComponentSource) &&
+    /window\.scrollTo\(0,\s*0\)/.test(shellComponentSource) &&
+    /scroller\.scrollTop = 0/.test(shellComponentSource),
+  'showcase shell explicitly resets window scroll after route navigation'
 );
 
 assert(


### PR DESCRIPTION
## Summary
- Adds an explicit route-navigation scroll reset in the showcase shell so real footer `routerLink` clicks land at the top of the next page.
- Updates the Docker showcase build to use `npm run build`, ensuring the Angular `prebuild` step regenerates crawler files before Fly deploys.
- Commits regenerated crawler artifacts so `llms-full.txt` matches the source and crawler smoke expectations.

## Root Cause
- Angular router scroll restoration alone did not reset scroll position for real footer clicks in production; `/about` footer navigation to `/lattice` preserved the prior deep scroll offset.
- The deploy Dockerfile used `npx ng build`, bypassing `prebuild`, so production shipped stale `llms-full.txt` content.

## Validation
- `node tests/showcase-angular-foundation.test.js`
- `npm --prefix showcase/angular run build`
- `BASE_URL=http://127.0.0.1:4300 npm --prefix showcase/angular run smoke:crawler`
- Local native browser check: from `/about` at `scrollY≈5306`, clicked footer `Lattice`; `/lattice` landed at `scrollY=0`.