### PR TITLE
[codex] Fix showcase deploy crawler manifest context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 !showcase/angular/
 !showcase/assets/
 !showcase/js/
+!extension/manifest.json
 
 # Re-ignore things inside those dirs we don't need
 showcase/server/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm ci
 COPY showcase/angular/ ./
 COPY showcase/assets/ ../assets/
 COPY showcase/js/ ../js/
+COPY extension/manifest.json ../extension/manifest.json
 RUN npm run build -- --configuration production
 
 # ---

--- a/tests/showcase-angular-foundation.test.js
+++ b/tests/showcase-angular-foundation.test.js
@@ -35,6 +35,7 @@ console.log('\n--- showcase angular foundation contracts ---');
 
 const rootPackageSource = readIfPresent('package.json');
 const dockerfileSource = readIfPresent('Dockerfile');
+const dockerignoreSource = readIfPresent('.dockerignore');
 const angularConfigSource = readIfPresent('showcase/angular/angular.json');
 const mainSource = readIfPresent('showcase/angular/src/main.ts');
 const appConfigSource = readIfPresent('showcase/angular/src/app/app.config.ts');
@@ -116,6 +117,12 @@ assert(
 assert(
   /RUN npm run build -- --configuration production/.test(dockerfileSource),
   'Docker showcase build runs npm build so prebuild regenerates crawler files before deploy'
+);
+
+assert(
+  /COPY extension\/manifest\.json \.\.\/extension\/manifest\.json/.test(dockerfileSource) &&
+    /^!extension\/manifest\.json$/m.test(dockerignoreSource),
+  'Docker showcase build includes extension manifest for crawler version generation'
 );
 
 // outputPath can be a string or an object { base, browser }


### PR DESCRIPTION
## Summary
- include `extension/manifest.json` in the Docker build context
- copy that manifest into the Angular build stage where the crawler prebuild expects it
- add a source contract so future Docker deploy builds keep the manifest available

## Root cause
PR #97 correctly changed Docker to run `npm run build` so the Angular `prebuild` regenerates crawler files during deployment. The Docker build stage only copied the showcase Angular/assets/js directories, so the crawler script could not read `/extension/manifest.json` when writing `version.ts`.

## Validation
- `node tests/showcase-angular-foundation.test.js`
- `npm --prefix showcase/angular run build`
- `docker build --target angular-build -t fsb-showcase-angular-build-check .`
