### PR TITLE
docs: add community guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# Code of Conduct
+
+## Our Commitment
+
+FSB aims to be a welcoming, respectful, and professional project for everyone who participates.
+
+## Expected Behavior
+
+1. Treat people with respect and assume good intent.
+2. Offer constructive feedback and keep discussion focused on the project.
+3. Respect differing experiences, perspectives, and skill levels.
+
+## Unacceptable Behavior
+
+1. Harassment, discrimination, threats, or personal attacks.
+2. Deliberate disruption of discussions, Issues, or pull requests.
+3. Publishing private information without permission.
+
+## Enforcement
+
+Maintainers may edit or remove content, reject contributions, or limit participation when behavior conflicts with this policy.
+
+## Reporting
+
+Report conduct concerns by opening a [GitHub Issue](https://github.com/fullselfbrowsing/FSB/issues). Include enough context for maintainers to review the concern.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to FSB
+
+Thank you for contributing to FSB.
+
+## Start With an Issue
+
+Open a GitHub Issue before beginning a substantial feature, behavior change, or architectural change. This lets maintainers confirm the direction and avoid duplicate work.
+
+Small documentation corrections and focused fixes can be submitted directly as a pull request.
+
+## Set Up Locally
+
+Follow the Local Development Setup section in the README. It covers prerequisites, installation, and how to run FSB during development.
+
+## Before Opening a Pull Request
+
+1. Keep changes focused and explain the user visible impact.
+2. Update relevant documentation when behavior or configuration changes.
+3. Run the checks that cover the change. For general changes, run:
+
+```sh
+npm run validate:extension
+npm test
+npm run test:mcp-smoke
+```
+
+4. Link the related Issue and describe what you tested in the pull request.
+
+## Security
+
+Do not report security vulnerabilities in public Issues or pull requests. Contact a maintainer privately through GitHub so that responsible disclosure can be arranged.


### PR DESCRIPTION
## Summary

Adds `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`.

## Why

FSB did not have GitHub community guidance files.

## Impact

Contributors now have clear participation and contribution expectations. GitHub will surface both documents as repository tabs.

## Validation

Confirmed that the branch contains one commit and only the two intended files. Confirmed `npm run validate:extension`, `npm test`, and `npm run test:mcp-smoke` exist. Ran `git diff --check`.
