### PR TITLE
fix(showcase): pin the vite peer @types/node that npm 10 resolves

### DIFF
--- a/showcase/angular/package-lock.json
+++ b/showcase/angular/package-lock.json
@@ -1004,6 +1004,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@angular/build/node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@angular/build/node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
@@ -1016,6 +1028,15 @@
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@angular/build/node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@angular/build/node_modules/vite": {
       "version": "7.3.2",


### PR DESCRIPTION
`npm ci` fails on `main` in the `chrome-extension` workflow:

```
npm error Missing: @types/node@26.4.0 from lock file
npm error Missing: undici-types@8.3.0 from lock file
```

## Cause

`@angular/build` nests `vite@7.3.2`, whose peer range for `@types/node` is `^20.19.0 || >=22.12.0`. The hoisted `@types/node@18.19.130` does not satisfy it, so **npm 10** — the version CI's Node 20 ships — resolves that optional peer to the latest release and expects it in the lock. **npm 11** skips the peer entirely, which is why the lock was never written with it and why this reproduces only in CI.

It is time-triggered, not merge-triggered: it reproduces on pre-merge `main` (`96bdcedc`) under npm 10.8.2, and started the moment `@types/node@26.x` was published. This workflow does not run on pull requests, so no PR check covered it.

## Fix

Graft the two entries npm 10 resolves. Regenerating the whole lock under npm 10 was the obvious alternative but it strips the `libc` metadata npm 11 records for the platform-specific rollup/esbuild binaries (78 lines removed), so the entries were lifted from npm 10's own output instead and inserted into the existing lock.

## Verification

- `npm ci --dry-run` clean under **both** npm 10.8.2 and npm 11.19.0
- `npm --prefix showcase/angular run build` succeeds
- `npm run validate:extension` and `npm run package:extension` pass
- Diff is +21 lines, 0 removed